### PR TITLE
Fix setting filetype twice

### DIFF
--- a/ftdetect/eelixir.vim
+++ b/ftdetect/eelixir.vim
@@ -1,2 +1,0 @@
-au BufRead,BufNewFile *.eex set filetype=eelixir
-au FileType eelixir setl sw=2 sts=2 et iskeyword+=!,?

--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,9 +1,17 @@
-au BufRead,BufNewFile *.ex,*.exs set filetype=elixir
-au FileType elixir setl sw=2 sts=2 et iskeyword+=!,?
+function! s:setf(filetype) abort
+    if &filetype !=# a:filetype
+        let &filetype = a:filetype
+    endif
+endfunction
+
+au BufRead,BufNewFile *.ex,*.exs call s:setf('elixir')
+au BufRead,BufNewFile *.eex call s:setf('eelixir')
+
+au FileType elixir,eelixir setl sw=2 sts=2 et iskeyword+=!,?
 
 function! s:DetectElixir()
     if getline(1) =~ '^#!.*\<elixir\>'
-        set filetype=elixir
+        call s:setf('elixir')
     endif
 endfunction
 


### PR DESCRIPTION
For some reason `setf` didn't work with `vimrunner`. This is solution from `vim-ruby`.