### PR TITLE
Updating errorformat for issue #76

### DIFF
--- a/compiler/exunit.vim
+++ b/compiler/exunit.vim
@@ -14,15 +14,15 @@ endif
 
 let s:cpo_save = &cpo
 set cpo-=C
-
 CompilerSet makeprg=mix\ test
 CompilerSet errorformat=
-  \**\ (%\\w%\\+)\ %f:%l:\ %m,
-  \%+Z\ \ \ \ \ \ \ %f:%l,
-  \%+G%>\ \ \ \ \ \ \ (%\\w%\\+)\ %f:%l:\ %m,
   \%E\ \ %n)\ %m,
+  \%+G\ \ \ \ \ **\ %m,
+  \%+G\ \ \ \ \ stacktrace:,
   \%C\ \ \ \ \ %f:%l,
-  \%+G%.%#
+  \%+G\ \ \ \ \ \ \ (%\\w%\\+)\ %f:%l:\ %m,
+  \%+G\ \ \ \ \ \ \ %f:%l:\ %.%#,
+  \**\ (%\\w%\\+)\ %f:%l:\ %m
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/compiler/exunit.vim
+++ b/compiler/exunit.vim
@@ -16,7 +16,13 @@ let s:cpo_save = &cpo
 set cpo-=C
 
 CompilerSet makeprg=mix\ test
-CompilerSet errorformat=%A\ \ %.)\ %m(%.%#),%C\ \ \ \ \ **%m,%C\ \ \ \ \ \ \ %m,%Z\ \ \ \ \ at\ %f:%l,%-G%.%#
+CompilerSet errorformat=
+  \**\ (%\\w%\\+)\ %f:%l:\ %m,
+  \%+Z\ \ \ \ \ \ \ %f:%l,
+  \%+G%>\ \ \ \ \ \ \ (%\\w%\\+)\ %f:%l:\ %m,
+  \%E\ \ %n)\ %m,
+  \%C\ \ \ \ \ %f:%l,
+  \%+G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
Updating the error format for #76  to process: * `** (SyntaxError) file:# error message` * `  #) test test unit fail message` * process the multi-line failures from ExUnit and highlight each file; Shortcomings at the moment is there is not a good way to distinguish
local errors vs dependency errors. This can be enhanced by changing the
output formatters to intelligent detect the local app name. For now all
the files are captured and it allows jumping to file from quickfix list,
but obviously erlang libs go to an empty new file