### PR TITLE
Add syntax rule for interpolation in char lists

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -74,7 +74,7 @@ syn region elixirRegex matchgroup=elixirRegexDelimiter start="%r/" end="/[uiomxf
 syn cluster elixirRegexSpecial    contains=elixirRegexEscape,elixirRegexCharClass,elixirRegexQuantifier,elixirRegexEscapePunctuation
 syn cluster elixirStringContained contains=elixirInterpolation,elixirRegexEscape,elixirRegexCharClass
 
-syn region elixirString        matchgroup=elixirStringDelimiter start="'" end="'" skip="\\'\|\\\\"
+syn region elixirString        matchgroup=elixirStringDelimiter start="'" end="'" skip="\\'\|\\\\" contains=@elixirStringContained
 syn region elixirString        matchgroup=elixirStringDelimiter start='"' end='"' skip='\\"' contains=@elixirStringContained
 syn region elixirInterpolation matchgroup=elixirInterpolationDelimiter start="#{" end="}" contained contains=ALLBUT,elixirComment,@elixirNotTop
 


### PR DESCRIPTION
Elixir has string interpolation in single quoted strings as well.