### PR TITLE
Enable "gf" for jumping to a module

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -18,3 +18,39 @@ endif
 
 setlocal comments=:#
 setlocal commentstring=#\ %s
+
+function! GetElixirFilename(word)
+  let word = a:word
+
+  " get first thing that starts uppercase, until the first space or end of line
+  let word = substitute(word,'^\s*\(\u[^ ]\+\).*$','\1','g')
+
+  " remove any trailing characters that don't look like a nested module
+  let word = substitute(word,'\.\U.*$','','g')
+
+  " replace module dots with slash
+  let word = substitute(word,'\.','/','g')
+
+  " remove any special chars
+  let word = substitute(word,'[^A-z0-9-_/]','','g')
+
+  " convert to snake_case
+  let word = substitute(word,'\(\u\+\)\(\u\l\)','\1_\2','g')
+  let word = substitute(word,'\(\u\+\)\(\u\l\)','\1_\2','g')
+  let word = substitute(word,'\(\l\|\d\)\(\u\)','\1_\2','g')
+  let word = substitute(word,'-','_','g')
+  let word = tolower(word)
+
+  return word
+endfunction
+
+let &l:path =
+      \ join([
+      \   getcwd().'/lib',
+      \   getcwd().'/src',
+      \   getcwd().'/deps/**/lib',
+      \   getcwd().'/deps/**/src',
+      \   &g:path
+      \ ], ',')
+setlocal includeexpr=GetElixirFilename(v:fname)
+setlocal suffixesadd=.ex,.exs,.eex,.erl,.yrl,.hrl


### PR DESCRIPTION
If you put your cursor on a module name, or select a module name, you can now use `gf` to jump to the corresponding file. Basically, dots are converted to slashes, and the words are converted to snake case. If the file containing the module does not match this convention, it will not be found and we cannot do much about it in a simple way.

This works pretty well so far, the only issue I am having is with nested modules. Suppose you have these files in your lib directory:

```
lib
├── my_app
│   ├── foo
│   │   └── bar.ex
│   └── foo.ex
└── my_app.ex
```

Now let's see some test cases:

```
MyApp          # jumps to lib/my_app/
MyApp.Foo      # jumps to lib/my_app/foo/
MyApp.Foo.Bar  # jumps to lib/my_app/foo/bar.ex
```

Unfortunately, if there is a directory with the same name (except the file extension of course), Vim will prefer to open the directory. Maybe it's a limitation of Vim's builtin file finding feature, I am not sure. I looked at vim-ruby and they remap `gf`, but I don't like the idea of remapping builtin commands. If anyone knows a way around this, please help me improve it!

Other than that I found that this little helper became a pretty essential part of my Elixir development workflow. I am looking forward to your comments and suggestions.

Consider this a WIP, I am still planning to add tests. I will need to take a look into the test framework first, though.