### PR TITLE
Look up docs with the "K" command

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -18,3 +18,6 @@ endif
 
 setlocal comments=:#
 setlocal commentstring=#\ %s
+
+setlocal iskeyword+=.
+setlocal keywordprg=iex\ -e\ 'Code.eval_string(\"import\ IEx.Helpers;\ h\ \"\ <>\ hd(System.argv));\ System.halt(0)'\ --


### PR DESCRIPTION
This sets `iskeyword` to include `.`, so that expressions of the form `Module.function` will be treated as a whole when looking up documentation with the `K` command.

The matched expression is then passed as command line argument to the `keywordprg` which is defined as:

```
iex -e 'Code.eval_string("import IEx.Helpers; h " <> hd(System.argv)); System.halt(0)' -- {MATCHED_EXPRESSION}
```

So if we press `K` in normal mode, we will see the documentation for the module or function under the cursor, as it is shown in IEx.