### PR TITLE
Set sane `formatoptions`

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -3,7 +3,6 @@ if (exists("b:did_ftplugin"))
 endif
 let b:did_ftplugin = 1
 
-
 " Matchit support
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0
@@ -54,3 +53,5 @@ let &l:path =
       \ ], ',')
 setlocal includeexpr=GetElixirFilename(v:fname)
 setlocal suffixesadd=.ex,.exs,.eex,.erl,.yrl,.hrl
+
+setlocal formatoptions-=t formatoptions+=croqlj


### PR DESCRIPTION
`formatoptions` is a string of rather opaque characters that describes
how automatic wrapping of lines is to be done. Previous to this change,
I noticed that causing a line to go over `textwidth` characters makes
vim automatically insert a hard wrap in the line. This causes invalid
(and ugly) elixir. This is because vim's default `formatoptions`
includes `t` which forces this behavior.

This change ensures that common `formatoptions` are set for elixir code
in vim. We remove `t` which is described in the help as:

```
t      Auto-wrap text using textwidth
```

We also ensure that the following options are set:

```
c    Auto-wrap comments using textwidth, inserting the current comment
     leader automatically.
r    Automatically insert the current comment leader after hitting
     <Enter> in Insert mode.
o    Automatically insert the current comment leader after hitting 'o' or
     'O' in Normal mode.
q    Allow formatting of comments with "gq".
     Note that formatting will not change blank lines or lines containing
     only the comment leader.  A new paragraph starts after such a line,
     or when the comment leader changes.
l    Long lines are not broken in insert mode: When a line was longer than
     'textwidth' when the insert command started, Vim does not
     automatically format it.
j    Where it makes sense, remove a comment leader when joining lines.  For
    example, joining:
      int i;   // the index ~
               // in the list ~
    Becomes:
      int i;   // the index in the list ~
```

These settings are similar to what I see in other syntax plugins.