### PR TITLE
indent symbols based on whitespace

### DIFF
--- a/spec/indent/lists_spec.rb
+++ b/spec/indent/lists_spec.rb
@@ -81,10 +81,20 @@ describe "Indenting" do
     .should be_elixir_indentation
   end
 
+  specify "lists without whitespace" do
+    <<-EOF
+    def project do
+      [{:bar, path: "deps/umbrella/apps/bar"},
+       {:umbrella, path: "deps/umbrella"}]
+    end
+    EOF
+    .should be_elixir_indentation
+  end
+
   specify "lists with line break after square brackets" do
     <<-EOF
     def project do
-      deps: [
+      [
         { :bar, path: "deps/umbrella/apps/bar" },
         { :umbrella, path: "deps/umbrella" }
       ]


### PR DESCRIPTION
the default mix.exs for example:

```
def project do
  [app: :foo,
   version: "0.0.1",
   elixir: "~> 1.2"
   deps: deps]
end

```