### PR TITLE
Use elixirModuleDeclaration for highlights

### DIFF
--- a/spec/syntax/demodule_spec.rb
+++ b/spec/syntax/demodule_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "Defmodule syntax" do
+  it "defines `defmodule` keyword as elixirModuleDefine" do
+    <<-EOF
+      defmodule HelloPhoenix.HelloController do
+    EOF
+    .should include_elixir_syntax('elixirModuleDefine', 'defmodule')
+  end
+
+  it "defines module name as elixirModuleDeclaration" do
+    <<-EOF
+      defmodule HelloPhoenix.HelloController do
+    EOF
+    .should include_elixir_syntax('elixirModuleDeclaration', 'HelloPhoenix.HelloController')
+  end
+
+  it "does not define module name as elixirAlias" do
+    <<-EOF
+      defmodule HelloPhoenix.HelloController do
+    EOF
+    .should_not include_elixir_syntax('elixirAlias', 'HelloPhoenix.HelloController')
+  end
+
+  it "defines `do` keyword as elixirBlock" do
+    <<-EOF
+      defmodule HelloPhoenix.HelloController do
+    EOF
+    .should include_elixir_syntax('elixirBlock', 'do')
+  end
+
+end
+

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -126,7 +126,7 @@ syn keyword elixirCallbackDefine      defcallback    nextgroup=elixirCallbackDec
 syn keyword elixirStructDefine        defstruct      skipwhite skipnl
 
 " Declarations
-syn match  elixirModuleDeclaration      "[^[:space:];#<]\+"        contained contains=elixirAlias nextgroup=elixirBlock     skipwhite skipnl
+syn match  elixirModuleDeclaration      "[^[:space:];#<]\+"        contained                      nextgroup=elixirBlock     skipwhite skipnl
 syn match  elixirFunctionDeclaration    "[^[:space:];#<,()\[\]]\+" contained                      nextgroup=elixirArguments skipwhite skipnl
 syn match  elixirProtocolDeclaration    "[^[:space:];#<]\+"        contained contains=elixirAlias                           skipwhite skipnl
 syn match  elixirImplDeclaration        "[^[:space:];#<]\+"        contained contains=elixirAlias                           skipwhite skipnl


### PR DESCRIPTION
I'm trying to update the Tomorrow colorscheme, so it better matches syntax highlighting in official elixir documentation. One of the challenges I've met is I want module name in `defmodule` statement to
have aqua color and when it's not in `defmodule`, it must be orange.
<img width="282" alt="screen shot 2016-06-07 at 19 28 52" src="https://cloud.githubusercontent.com/assets/358764/15866284/acdaa97e-2ce6-11e6-8f0b-45dfb79a225e.png">
As I understand, it's impossible to do with current syntax. So I suggest this pull request. If you think it's a good idea, then I'll do the same for [all remaining matchers for declarations](https://github.com/elixir-lang/vim-elixir/pull/158).
Before this commit module name is highlighted as `elixirAlias`, and after this commit it's recognised as `elixirModuleDeclaration`.
It's very helpful to make your vim colorscheme more customisable.