### PR TITLE
Highlight doc as `Comment` instead of `String`

### DIFF
--- a/spec/syntax/heredoc_spec.rb
+++ b/spec/syntax/heredoc_spec.rb
@@ -38,33 +38,4 @@ describe "Heredoc syntax" do
       .should include_elixir_syntax('elixirInterpolation', 'bar')
     end
   end
-
-  describe "character list" do
-    it "with multiline content" do
-      <<-EOF
-        @doc """
-        foo
-        """
-      EOF
-      .should include_elixir_syntax('elixirDocString', 'foo')
-    end
-
-    it "escapes quotes unless only preceded by whitespace" do
-      <<-EOF
-        @doc '''
-        foo '''
-        '''
-      EOF
-      .should include_elixir_syntax('elixirDocString', %q(^\s*\zs'''))
-    end
-
-    it "with interpolation" do
-      <<-EOF
-        @doc '''
-        foo \#{bar}
-        '''
-      EOF
-      .should include_elixir_syntax('elixirInterpolation', 'bar')
-    end
-  end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -79,9 +79,7 @@ syn region elixirString        matchgroup=elixirStringDelimiter start='"' end='"
 syn region elixirInterpolation matchgroup=elixirInterpolationDelimiter start="#{" end="}" contained contains=ALLBUT,elixirComment,@elixirNotTop
 
 syn region elixirDocStringStart matchgroup=elixirDocString start=+"""+ end=+$+ oneline contains=ALLBUT,@elixirNotTop
-syn region elixirDocStringStart matchgroup=elixirDocString start=+'''+ end=+$+ oneline contains=ALLBUT,@elixirNotTop
 syn region elixirDocString     start=+\z("""\)+ end=+^\s*\zs\z1+ contains=elixirDocStringStart,elixirTodo,elixirInterpolation,@Spell keepend fold
-syn region elixirDocString     start=+\z('''\)+ end=+^\s*\zs\z1+ contains=elixirDocStringStart,elixirTodo,elixirInterpolation,@Spell keepend fold
 
 syn match elixirAtomInterpolated   ':\("\)\@=' contains=elixirString
 syn match elixirString             "\(\w\)\@<!?\%(\\\(x\d{1,2}\|\h{1,2}\h\@!\>\|0[0-7]{0,2}[0-7]\@!\>\|[^x0MC]\)\|(\\[MC]-)+\w\|[^\s\\]\)"
@@ -170,7 +168,7 @@ hi def link elixirVariable               Identifier
 hi def link elixirSelf                   Identifier
 hi def link elixirUnusedVariable         Comment
 hi def link elixirNumber                 Number
-hi def link elixirDocString              String
+hi def link elixirDocString              Comment
 hi def link elixirAtomInterpolated       elixirAtom
 hi def link elixirRegex                  elixirString
 hi def link elixirRegexEscape            elixirSpecial


### PR DESCRIPTION
From now on the documentation code will be highlighted as `Comment`
instead of `String`. Also documentation with `'''` will be not
recognised, because it's not a valid documentation anymore.

Fixes #162.

![nvim](https://cloud.githubusercontent.com/assets/120483/17207463/9cc512fc-54ac-11e6-90ae-0afa712ecffd.png)
