### PR TITLE
Test to show @doc with sigil_S don't show as elixirDocString.

### DIFF
--- a/spec/syntax/heredoc_spec.rb
+++ b/spec/syntax/heredoc_spec.rb
@@ -12,7 +12,7 @@ describe 'Heredoc syntax' do
       EOF
     end
 
-    pending 'doc with sigil_S triple double-quoted multiline content' do
+    it 'doc with sigil_S triple double-quoted multiline content' do
       expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
         @doc ~S"""
         foo
@@ -20,19 +20,11 @@ describe 'Heredoc syntax' do
       EOF
     end
 
-    pending 'doc with sigil_S triple single-quoted multiline content' do
+    it 'doc with sigil_S triple single-quoted multiline content' do
       expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
         @doc ~S'''
         foo
         '''
-      EOF
-    end
-
-    it 'doc escapes quotes unless only preceded by whitespace' do
-      expect(<<~EOF).to include_elixir_syntax('elixirDocString', %q(^\s*\zs"""))
-        @doc """
-        foo """
-        """
       EOF
     end
 

--- a/spec/syntax/heredoc_spec.rb
+++ b/spec/syntax/heredoc_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'Heredoc syntax' do
   describe 'binary' do
-    it 'with multiline content' do
+    it 'doc with multiline content' do
       expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
         @doc """
         foo
@@ -12,7 +12,23 @@ describe 'Heredoc syntax' do
       EOF
     end
 
-    it 'escapes quotes unless only preceded by whitespace' do
+    it 'doc with sigil_S triple double-quoted multiline content' do
+      expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
+        @doc ~S"""
+        foo
+        """
+      EOF
+    end
+
+    it 'doc with sigil_S triple single-quoted multiline content' do
+      expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
+        @doc ~S'''
+        foo
+        '''
+      EOF
+    end
+
+    it 'doc escapes quotes unless only preceded by whitespace' do
       expect(<<~EOF).to include_elixir_syntax('elixirDocString', %q(^\s*\zs"""))
         @doc """
         foo """
@@ -20,12 +36,14 @@ describe 'Heredoc syntax' do
       EOF
     end
 
-    it 'with interpolation' do
-      expect(<<~EOF).to include_elixir_syntax('elixirInterpolation', 'bar')
+    it 'doc with interpolation' do
+      ex = <<~EOF
         @doc """
         foo \#{bar}
         """
       EOF
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
+      expect(ex).to include_elixir_syntax('elixirInterpolation', 'bar')
     end
 
     it 'interpolation in heredoc must be string' do

--- a/spec/syntax/heredoc_spec.rb
+++ b/spec/syntax/heredoc_spec.rb
@@ -5,27 +5,33 @@ require 'spec_helper'
 describe 'Heredoc syntax' do
   describe 'binary' do
     it 'doc with multiline content' do
-      expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
-        @doc """
+      ex = <<~EOF
+        @callbackdoc """
         foo
         """
       EOF
+      expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
     it 'doc with sigil_S triple double-quoted multiline content' do
-      expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
+      ex = <<~EOF
         @doc ~S"""
         foo
         """
       EOF
+      expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
     it 'doc with sigil_S triple single-quoted multiline content' do
-      expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
+      ex = <<~EOF
         @doc ~S'''
         foo
         '''
       EOF
+      expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
+      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
     it 'doc with interpolation' do

--- a/spec/syntax/heredoc_spec.rb
+++ b/spec/syntax/heredoc_spec.rb
@@ -12,7 +12,7 @@ describe 'Heredoc syntax' do
       EOF
     end
 
-    it 'doc with sigil_S triple double-quoted multiline content' do
+    pending 'doc with sigil_S triple double-quoted multiline content' do
       expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
         @doc ~S"""
         foo
@@ -20,7 +20,7 @@ describe 'Heredoc syntax' do
       EOF
     end
 
-    it 'doc with sigil_S triple single-quoted multiline content' do
+    pending 'doc with sigil_S triple single-quoted multiline content' do
       expect(<<~EOF).to include_elixir_syntax('elixirDocString', 'foo')
         @doc ~S'''
         foo

--- a/spec/syntax/heredoc_spec.rb
+++ b/spec/syntax/heredoc_spec.rb
@@ -21,6 +21,7 @@ describe 'Heredoc syntax' do
         """
       EOF
       expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
+      expect(ex).to include_elixir_syntax('elixirSigilDelimiter', 'S"""')
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
     end
 
@@ -31,7 +32,17 @@ describe 'Heredoc syntax' do
         '''
       EOF
       expect(ex).to include_elixir_syntax('elixirVariable', 'doc')
+      expect(ex).to include_elixir_syntax('elixirSigilDelimiter', "S'''")
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
+    end
+
+    it 'doc with triple single-quoted multiline content is not a doc string' do
+      ex = <<~EOF
+        @doc '''
+        foo
+        '''
+      EOF
+      expect(ex).not_to include_elixir_syntax('elixirDocString', 'foo')
     end
 
     it 'doc with interpolation' do
@@ -41,6 +52,7 @@ describe 'Heredoc syntax' do
         """
       EOF
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
+      expect(ex).to include_elixir_syntax('elixirStringDelimiter', '"""')
       expect(ex).to include_elixir_syntax('elixirInterpolation', 'bar')
     end
 

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -112,7 +112,8 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l("            
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\zs\z1\s*$+ skip=+\\"+ fold
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\zs\z1\s*$+ skip=+\\'+ fold
 
-syn match elixirDocString +\%(@\w*doc\s*\)\@<=\%(\%(\%(\~[Ss]\)\?\("""\|'''\)\)\_.\{-}\_^\s*\1\|".\{-\}"\)+ contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+ end=+\z1+ contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\|"""\)+ end=+\z1+ contains=elixirTodo,elixirInterpolation,@Spell fold
 
 " Defines
 syn keyword elixirDefine              def            nextgroup=elixirFunctionDeclaration    skipwhite skipnl

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -85,9 +85,6 @@ syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('''\)+ end=+
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("""\)+ end=+^\s*\z1+ skip=+"\|\\\\+  contains=@elixirStringContained
 syn region elixirInterpolation matchgroup=elixirInterpolationDelimiter start="#{" end="}" contained contains=ALLBUT,elixirComment,@elixirNotTop
 
-syn region elixirDocString matchgroup=elixirStringDelimiter start=+\z(@\w*doc\s\+\)\z("""\|'''\)+    end=+^\s*\zs\z2\s*$+ contains=elixirTodo,elixirInterpolation,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\z(@\w*doc\s\+\~S\)\z("""\|'''\)+ end=+^\s*\zs\z2\s*$+ contains=elixirTodo,elixirInterpolation,@Spell fold
-
 syn match elixirAtomInterpolated   ':\("\)\@=' contains=elixirString
 syn match elixirString             "\(\w\)\@<!?\%(\\\(x\d{1,2}\|\h{1,2}\h\@!\>\|0[0-7]{0,2}[0-7]\@!\>\|[^x0MC]\)\|(\\[MC]-)+\w\|[^\s\\]\)"
 
@@ -114,6 +111,8 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l("            
 " Sigils surrounded with docString
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\zs\z1\s*$+ skip=+\\"+ fold
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\zs\z1\s*$+ skip=+\\'+ fold
+
+syn match elixirDocString +\%(@\w*doc\s*\)\@<=\%(\%(\%(\~[Ss]\)\?\("""\|'''\)\)\_.\{-}\_^\s*\1\|".\{-\}"\)+ contains=elixirTodo,elixirInterpolation,@Spell fold
 
 " Defines
 syn keyword elixirDefine              def            nextgroup=elixirFunctionDeclaration    skipwhite skipnl

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -85,7 +85,8 @@ syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('''\)+ end=+
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("""\)+ end=+^\s*\z1+ skip=+"\|\\\\+  contains=@elixirStringContained
 syn region elixirInterpolation matchgroup=elixirInterpolationDelimiter start="#{" end="}" contained contains=ALLBUT,elixirComment,@elixirNotTop
 
-syn match elixirDocString +\(@\w*doc\s*\)\@<=\%("""\_.\{-}\_^\s*"""\|".\{-\}"\)+ contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirStringDelimiter start=+\z(@\w*doc\s\+\)\z("""\|'''\)+    end=+^\s*\zs\z2\s*$+ contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\z(@\w*doc\s\+\~S\)\z("""\|'''\)+ end=+^\s*\zs\z2\s*$+ contains=elixirTodo,elixirInterpolation,@Spell fold
 
 syn match elixirAtomInterpolated   ':\("\)\@=' contains=elixirString
 syn match elixirString             "\(\w\)\@<!?\%(\\\(x\d{1,2}\|\h{1,2}\h\@!\>\|0[0-7]{0,2}[0-7]\@!\>\|[^x0MC]\)\|(\\[MC]-)+\w\|[^\s\\]\)"
@@ -111,8 +112,8 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l\["           
 syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l("                end=")"   skip="\\\\\|\\)"   contains=@elixirStringContained,elixirRegexEscapePunctuation fold
 
 " Sigils surrounded with docString
-syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\zs\z1+ skip=+\\"+ fold
-syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\zs\z1+ skip=+\\'+ fold
+syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\zs\z1\s*$+ skip=+\\"+ fold
+syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\zs\z1\s*$+ skip=+\\'+ fold
 
 " Defines
 syn keyword elixirDefine              def            nextgroup=elixirFunctionDeclaration    skipwhite skipnl


### PR DESCRIPTION
A lot of Elixir's documentation is written with `sigil_S` for `@moduledoc`s and function `@doc`s. Currently they are all matched as `elixirSigil`, instead of `elixirDocString`.

I haven't been able to fix it, so I thought I'd submit a PR with the failing test case.