### PR TITLE
adds support for vimrunners other than gvim

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -155,11 +155,18 @@ end
   end
 end
 
+def start_vim
+  return Vimrunner.start_gvim if system('which gvim')
+  return Vimrunner.start_mvim if system('which mvim')
+  return Vimrunner.start if system('which vim')
+  raise "Couldn't find suitable vim version"
+end
+
 Vimrunner::RSpec.configure do |config|
   config.reuse_server = true
 
   config.start_vim do
-    VIM = Vimrunner.start_gvim
+    VIM = start_vim
     VIM.add_plugin(File.expand_path('..', __dir__), 'ftdetect/elixir.vim')
     VIM
   end


### PR DESCRIPTION
Adds support for running tests with other vim derivatives. Defaults to gvim, then looks for mvim, and finally tries vanilla vim