### PR TITLE
match overridden keywords as elixirId instead of elixirKeyword

### DIFF
--- a/spec/syntax/keyword_spec.rb
+++ b/spec/syntax/keyword_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Keyword syntax' do
+  it 'for used as keyword' do
+    expect(<<~EOF).to include_elixir_syntax('elixirKeyword', 'for')
+    for v <- [1, 3, 3]
+    EOF
+  end
+
+  it 'case used as keyword' do
+    expect(<<~EOF).to include_elixir_syntax('elixirKeyword', 'case')
+    case true do
+    EOF
+  end
+end

--- a/spec/syntax/module_function_spec.rb
+++ b/spec/syntax/module_function_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Module function syntax' do
+  it 'for used as module function' do
+    expect(<<~EOF).to include_elixir_syntax('elixirId', 'for')
+    OverridesDefault.for
+    EOF
+  end
+
+  it 'case used as module function' do
+    expect(<<~EOF).to include_elixir_syntax('elixirId', 'case')
+    OverridesDefault.case
+    EOF
+  end
+end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -16,9 +16,11 @@ syn cluster elixirDeclaration contains=elixirFunctionDeclaration,elixirModuleDec
 syn match elixirComment '#.*' contains=elixirTodo,@Spell
 syn keyword elixirTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
 
-syn keyword elixirKeyword case when with cond for if unless try receive send
-syn keyword elixirKeyword exit raise throw after rescue catch else
-syn keyword elixirKeyword quote unquote super spawn spawn_link spawn_monitor
+syn match elixirId '\<[_a-zA-Z]\w*[!?]\?\>'
+
+syn match elixirKeyword '\(\.\)\@<!\<\(for\|case\|when\|with\|cond\|if\|unless\|try\|receive\|send\)\>'
+syn match elixirKeyword '\(\.\)\@<!\<\(exit\|raise\|throw\|after\|rescue\|catch\|else\)\>'
+syn match elixirKeyword '\(\.\)\@<!\<\(quote\|unquote\|super\|spawn\|spawn_link\|spawn_monitor\)\>'
 
 " Functions used on guards
 syn keyword elixirKeyword contained is_atom is_binary is_bitstring is_boolean
@@ -33,8 +35,6 @@ syn match elixirGuard '.*when.*' contains=ALLBUT,@elixirNotTop
 syn keyword elixirInclude import require alias use
 
 syn keyword elixirSelf self
-
-syn match elixirId '\<[_a-zA-Z]\w*[!?]\?\>'
 
 " This unfortunately also matches function names in function calls
 syn match elixirUnusedVariable '\(([^)]*\)\@<=\<_\w*\>'


### PR DESCRIPTION
Noticed this when I was creating an API that looked like `Workspace.for(my_workspace)`. This change adds negative lookbehind to keywords to check if a `.` is present.

Note this would also affect some common GenServer encapsulation code like:

```ex
GenServer.spawn_link(__MODULE__, %{})
```

Which previously had `spawn_link` highlighted as a keyword