### PR TITLE
add syntax for ExUnit test/describe

### DIFF
--- a/spec/syntax/exunit_spec.rb
+++ b/spec/syntax/exunit_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ExUnit syntax' do
+  it 'test macro' do
+    expect(<<~EOF).to include_elixir_syntax('elixirExUnitMacro', 'test')
+    test 'that stuff works' do
+      assert true
+    end
+    EOF
+  end
+
+  it 'describe macro' do
+    expect(<<~EOF).to include_elixir_syntax('elixirExUnitMacro', 'describe')
+    describe 'some_function/1' do
+      test 'that stuff works' do
+        assert true
+      end
+    end
+    EOF
+  end
+end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -143,6 +143,9 @@ syn match  elixirOverridableDeclaration "[^[:space:];#<]\+"        contained con
 syn match  elixirExceptionDeclaration   "[^[:space:];#<]\+"        contained contains=elixirAlias                           skipwhite skipnl
 syn match  elixirCallbackDeclaration    "[^[:space:];#<,()\[\]]\+" contained contains=elixirFunctionDeclaration             skipwhite skipnl
 
+" ExUnit
+syn match  elixirExUnitMacro "\(^\s*\)\@<=\<\(test\|describe\)\>"
+
 hi def link elixirBlockInline            Keyword
 hi def link elixirBlockDefinition        Keyword
 hi def link elixirDefine                 Define
@@ -159,6 +162,7 @@ hi def link elixirOverridableDefine      Define
 hi def link elixirExceptionDefine        Define
 hi def link elixirCallbackDefine         Define
 hi def link elixirStructDefine           Define
+hi def link elixirExUnitMacro            Define
 hi def link elixirModuleDeclaration      Type
 hi def link elixirFunctionDeclaration    Function
 hi def link elixirMacroDeclaration       Macro


### PR DESCRIPTION
This matches ExUnit's `test` and `describe` macros http://elixir-lang.org/docs/stable/ex_unit/ExUnit.Case.html#describe/2