### PR TITLE
Use markdown syntax for `elixirDocString`

### DIFF
--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -2,8 +2,18 @@
 
 require 'spec_helper'
 
-describe 'Heredoc syntax' do
-  describe 'binary' do
+describe 'documentation syntax' do
+  describe 'string' do
+    it 'doc in double quotes' do
+      expect('@doc "foo"').to include_elixir_syntax('elixirDocString', 'foo')
+    end
+
+    it 'doc in sigil_S' do
+      expect('@doc ~S(foo)').to include_elixir_syntax('elixirDocString', 'foo')
+    end
+  end
+
+  describe 'heredoc' do
     it 'doc with multiline content' do
       ex = <<~EOF
         @callbackdoc """
@@ -54,36 +64,6 @@ describe 'Heredoc syntax' do
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
       expect(ex).to include_elixir_syntax('elixirStringDelimiter', '"""')
       expect(ex).to include_elixir_syntax('elixirInterpolation', 'bar')
-    end
-
-    it 'interpolation in heredoc must be string' do
-      expect(<<~EOF).to include_elixir_syntax('elixirString', 'test')
-      def function do
-        """
-        foo "test"
-        """
-      end
-      EOF
-    end
-
-    it 'interpolation in heredoc' do
-      expect(<<~'EOF').to include_elixir_syntax('elixirInterpolation', '#{')
-      def function do
-        """
-        foo "#{test}"
-        """
-      end
-      EOF
-    end
-
-    it 'interpolation in string in heredoc' do
-      expect(<<~'EOF').to include_elixir_syntax('elixirInterpolation', '#{')
-      def function do
-        """
-        foo #{test}
-        """
-      end
-      EOF
     end
   end
 end

--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -90,9 +90,22 @@ describe 'documentation syntax' do
       doctest with inline code `List.wrap([])`
       """
       EOF
-      VIM.command("let g:elixir_use_markdown_for_docs=1")
       expect(ex).to include_elixir_syntax('elixirDocString', 'doctest')
-      expect(ex).to include_elixir_syntax('markdownCode',   'wrap')
+      expect(ex).to include_elixir_syntax('elixirDocString',   'wrap')
+    end
+
+    describe "use markdown for docs" do
+      before(:each) { VIM.command("let g:elixir_use_markdown_for_docs = 1") }
+
+      it 'doc with inline code' do
+	ex = <<~'EOF'
+	@doc """
+	doctest with inline code `List.wrap([])`
+	"""
+	EOF
+	expect(ex).to include_elixir_syntax('elixirDocString', 'doctest')
+	expect(ex).to include_elixir_syntax('markdownCode',   'wrap')
+      end
     end
   end
 end

--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -61,9 +61,37 @@ describe 'documentation syntax' do
         foo #{bar}
         """
       EOF
-      expect(ex).to include_elixir_syntax('elixirDocString', 'foo')
-      expect(ex).to include_elixir_syntax('elixirStringDelimiter', '"""')
-      expect(ex).to include_elixir_syntax('elixirInterpolation', 'bar')
+      expect(ex).to     include_elixir_syntax('elixirDocString',       'foo')
+      expect(ex).to     include_elixir_syntax('elixirStringDelimiter', '"""')
+      expect(ex).not_to include_elixir_syntax('elixirInterpolation',   'bar')
+    end
+
+    it 'doc with doctest' do
+      ex = <<~'EOF'
+      @doc """
+      doctest
+
+      iex> Enum.map [1, 2, 3], fn(x) ->
+      ...>   x * 2
+      ...> end
+      [2, 4, 6]
+
+      """
+      EOF
+      expect(ex).to include_elixir_syntax('elixirDocString', 'doctest')
+      expect(ex).to include_elixir_syntax('markdownCodeBlock',   'map')
+      expect(ex).to include_elixir_syntax('markdownCodeBlock',   'x * 2')
+      expect(ex).to include_elixir_syntax('markdownCodeBlock',   '2, 4, 6')
+    end
+
+    it 'doc with inline code' do
+      ex = <<~'EOF'
+      @doc """
+      doctest with inline code `List.wrap([])`
+      """
+      EOF
+      expect(ex).to include_elixir_syntax('elixirDocString', 'doctest')
+      expect(ex).to include_elixir_syntax('markdownCode',   'wrap')
     end
   end
 end

--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -79,9 +79,9 @@ describe 'documentation syntax' do
       """
       EOF
       expect(ex).to include_elixir_syntax('elixirDocString', 'doctest')
-      expect(ex).to include_elixir_syntax('markdownCodeBlock',   'map')
-      expect(ex).to include_elixir_syntax('markdownCodeBlock',   'x * 2')
-      expect(ex).to include_elixir_syntax('markdownCodeBlock',   '2, 4, 6')
+      expect(ex).to include_elixir_syntax('elixirDocTest',   'map')
+      expect(ex).to include_elixir_syntax('elixirDocTest',   'x * 2')
+      expect(ex).to include_elixir_syntax('elixirDocTest',   '2, 4, 6')
     end
 
     it 'doc with inline code' do
@@ -90,6 +90,7 @@ describe 'documentation syntax' do
       doctest with inline code `List.wrap([])`
       """
       EOF
+      VIM.command("let g:elixir_use_markdown_for_docs=1")
       expect(ex).to include_elixir_syntax('elixirDocString', 'doctest')
       expect(ex).to include_elixir_syntax('markdownCode',   'wrap')
     end

--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -15,7 +15,7 @@ describe 'documentation syntax' do
 
   describe 'heredoc' do
     it 'doc with multiline content' do
-      ex = <<~EOF
+      ex = <<~'EOF'
         @callbackdoc """
         foo
         """
@@ -25,7 +25,7 @@ describe 'documentation syntax' do
     end
 
     it 'doc with sigil_S triple double-quoted multiline content' do
-      ex = <<~EOF
+      ex = <<~'EOF'
         @doc ~S"""
         foo
         """
@@ -36,7 +36,7 @@ describe 'documentation syntax' do
     end
 
     it 'doc with sigil_S triple single-quoted multiline content' do
-      ex = <<~EOF
+      ex = <<~'EOF'
         @doc ~S'''
         foo
         '''
@@ -47,7 +47,7 @@ describe 'documentation syntax' do
     end
 
     it 'doc with triple single-quoted multiline content is not a doc string' do
-      ex = <<~EOF
+      ex = <<~'EOF'
         @doc '''
         foo
         '''
@@ -55,10 +55,10 @@ describe 'documentation syntax' do
       expect(ex).not_to include_elixir_syntax('elixirDocString', 'foo')
     end
 
-    it 'doc with interpolation' do
-      ex = <<~EOF
+    it 'doc skip interpolation' do
+      ex = <<~'EOF'
         @doc """
-        foo \#{bar}
+        foo #{bar}
         """
       EOF
       expect(ex).to include_elixir_syntax('elixirDocString', 'foo')

--- a/spec/syntax/strings_spec.rb
+++ b/spec/syntax/strings_spec.rb
@@ -22,4 +22,38 @@ describe 'String syntax' do
       expect('do_something "foo #{test}"').to include_elixir_syntax('elixirInterpolation', 'test')
     end
   end
+
+  describe 'heredoc' do
+    it 'heredoc must be string' do
+      ex = <<~EOF
+      def function do
+        """
+        foo "test"
+        """
+      end
+      EOF
+      expect(ex).to include_elixir_syntax('elixirString', 'foo')
+      expect(ex).to include_elixir_syntax('elixirString', 'test')
+    end
+
+    it 'interpolation in string in heredoc' do
+      expect(<<~'EOF').to include_elixir_syntax('elixirInterpolation', '#{')
+      def function do
+        """
+        foo "#{test}"
+        """
+      end
+      EOF
+    end
+
+    it 'interpolation in heredoc' do
+      expect(<<~'EOF').to include_elixir_syntax('elixirInterpolation', '#{')
+      def function do
+        """
+        foo #{test}
+        """
+      end
+      EOF
+    end
+  end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -114,18 +114,29 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\zs\z1\s*$+ skip=+\\'+ fold
 
 " Documentation
-syn include @markdown syntax/markdown.vim
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S\z(/\|\"\|'\||\){1}" end="\z1" skip="\\\\\|\\\z1" contains=@markdown,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S{"                   end="}"   skip="\\\\\|\\}"   contains=@markdown,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S<"                   end=">"   skip="\\\\\|\\>"   contains=@markdown,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S\["                  end="\]"  skip="\\\\\|\\\]"  contains=@markdown,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S("                   end=")"   skip="\\\\\|\\)"   contains=@markdown,@Spell fold
-syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("\)+                 end=+\z1+ skip=+\\\\\|\\\z1+  contains=@markdown,@Spell
-syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+               end=+\z1+ contains=@markdown,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\|"""\)+    end=+\z1+ contains=@markdown,@Spell fold
+if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs
+  syn include @markdown syntax/markdown.vim
+  syn cluster elixirDocStringContained contains=@markdown,@Spell
 
-" doctests
-syn region markdownCodeBlock start="^\s*\%(iex\|\.\.\.\)\%((\d*)\)\?>\s" end="^\s*$" contained
+  " doctests
+  syn region markdownCodeBlock start="^\s*\%(iex\|\.\.\.\)\%((\d*)\)\?>\s" end="^\s*$" contained
+else
+  let g:elixir_use_markdown_for_docs = 0
+  syn cluster elixirDocStringContained contains=elixirDocTest,elixirTodo,@Spell
+
+  " doctests
+  syn region elixirDocTest start="^\s*\%(iex\|\.\.\.\)>\s" end="^\s*$" contained
+endif
+
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S\z(/\|\"\|'\||\){1}" end="\z1" skip="\\\\\|\\\z1" contains=@elixirDocStringContained fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S{"                   end="}"   skip="\\\\\|\\}"   contains=@elixirDocStringContained fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S<"                   end=">"   skip="\\\\\|\\>"   contains=@elixirDocStringContained fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S\["                  end="\]"  skip="\\\\\|\\\]"  contains=@elixirDocStringContained fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S("                   end=")"   skip="\\\\\|\\)"   contains=@elixirDocStringContained fold
+syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("\)+                 end=+\z1+ skip=+\\\\\|\\\z1+  contains=@markdown,@Spell
+syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+               end=+\z1+ contains=@elixirDocStringContained fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\)+ end=+\z1+ skip=+\\'+ contains=@elixirDocStringContained fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z("""\)+ end=+\z1+ skip=+\\"+ contains=@elixirDocStringContained fold
 
 " Defines
 syn keyword elixirDefine              def            nextgroup=elixirFunctionDeclaration    skipwhite skipnl
@@ -193,6 +204,7 @@ hi def link elixirSelf                   Identifier
 hi def link elixirUnusedVariable         Comment
 hi def link elixirNumber                 Number
 hi def link elixirDocString              Comment
+hi def link elixirDocTest                elixirKeyword
 hi def link elixirAtomInterpolated       elixirAtom
 hi def link elixirRegex                  elixirString
 hi def link elixirRegexEscape            elixirSpecial

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -114,14 +114,18 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\zs\z1\s*$+ skip=+\\'+ fold
 
 " Documentation
-syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S\z(/\|\"\|'\||\){1}" end="\z1" skip="\\\\\|\\\z1" contains=elixirTodo,elixirInterpolation,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S{"                end="}"   skip="\\\\\|\\}"   contains=elixirTodo,elixirInterpolation,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S<"                end=">"   skip="\\\\\|\\>"   contains=elixirTodo,elixirInterpolation,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S\["               end="\]"  skip="\\\\\|\\\]"  contains=elixirTodo,elixirInterpolation,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S("                end=")"   skip="\\\\\|\\)"   contains=elixirTodo,elixirInterpolation,@Spell fold
-syn region elixirDocString  matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=elixirTodo,elixirInterpolation,@Spell
-syn region elixirDocString matchgroup=elixirStringDelimiter  start=+\%(@\w*doc\s\+\)\@<=\z("""\)+ end=+\z1+ contains=elixirTodo,elixirInterpolation,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter   start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\|"""\)+ end=+\z1+ contains=elixirTodo,elixirInterpolation,@Spell fold
+syn include @markdown syntax/markdown.vim
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S\z(/\|\"\|'\||\){1}" end="\z1" skip="\\\\\|\\\z1" contains=@markdown,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S{"                   end="}"   skip="\\\\\|\\}"   contains=@markdown,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S<"                   end=">"   skip="\\\\\|\\>"   contains=@markdown,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S\["                  end="\]"  skip="\\\\\|\\\]"  contains=@markdown,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S("                   end=")"   skip="\\\\\|\\)"   contains=@markdown,@Spell fold
+syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("\)+                 end=+\z1+ skip=+\\\\\|\\\z1+  contains=@markdown,@Spell
+syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+               end=+\z1+ contains=@markdown,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\|"""\)+    end=+\z1+ contains=@markdown,@Spell fold
+
+" doctests
+syn region markdownCodeBlock start="^\s*\%(iex\|\.\.\.\)\%((\d*)\)\?>\s" end="^\s*$" contained
 
 " Defines
 syn keyword elixirDefine              def            nextgroup=elixirFunctionDeclaration    skipwhite skipnl

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -117,15 +117,12 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=
 if exists('g:elixir_use_markdown_for_docs') && g:elixir_use_markdown_for_docs
   syn include @markdown syntax/markdown.vim
   syn cluster elixirDocStringContained contains=@markdown,@Spell
-
-  " doctests
-  syn region markdownCodeBlock start="^\s*\%(iex\|\.\.\.\)\%((\d*)\)\?>\s" end="^\s*$" contained
 else
   let g:elixir_use_markdown_for_docs = 0
   syn cluster elixirDocStringContained contains=elixirDocTest,elixirTodo,@Spell
 
   " doctests
-  syn region elixirDocTest start="^\s*\%(iex\|\.\.\.\)>\s" end="^\s*$" contained
+  syn region elixirDocTest start="^\s*\%(iex\|\.\.\.\)\%((\d*)\)\?>\s" end="^\s*$" contained
 endif
 
 syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S\z(/\|\"\|'\||\){1}" end="\z1" skip="\\\\\|\\\z1" contains=@elixirDocStringContained fold

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -109,12 +109,19 @@ syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l\["           
 syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l("                end=")"   skip="\\\\\|\\)"   contains=@elixirStringContained,elixirRegexEscapePunctuation fold
 syn region elixirSigil matchgroup=elixirSigilDelimiter start="\~\l\/"               end="\/"  skip="\\\\\|\\\/"  contains=@elixirStringContained,elixirRegexEscapePunctuation fold
 
-" Sigils surrounded with docString
+" Sigils surrounded with heredoc
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z("""\)+ end=+^\s*\zs\z1\s*$+ skip=+\\"+ fold
 syn region elixirSigil matchgroup=elixirSigilDelimiter start=+\~\a\z('''\)+ end=+^\s*\zs\z1\s*$+ skip=+\\'+ fold
 
-syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+ end=+\z1+ contains=elixirTodo,elixirInterpolation,@Spell fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\|"""\)+ end=+\z1+ contains=elixirTodo,elixirInterpolation,@Spell fold
+" Documentation
+syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S\z(/\|\"\|'\||\){1}" end="\z1" skip="\\\\\|\\\z1" contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S{"                end="}"   skip="\\\\\|\\}"   contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S<"                end=">"   skip="\\\\\|\\>"   contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S\["               end="\]"  skip="\\\\\|\\\]"  contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter   start="\%(@\w*doc\s\+\)\@<=\~S("                end=")"   skip="\\\\\|\\)"   contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString  matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=elixirTodo,elixirInterpolation,@Spell
+syn region elixirDocString matchgroup=elixirStringDelimiter  start=+\%(@\w*doc\s\+\)\@<=\z("""\)+ end=+\z1+ contains=elixirTodo,elixirInterpolation,@Spell fold
+syn region elixirDocString matchgroup=elixirSigilDelimiter   start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\|"""\)+ end=+\z1+ contains=elixirTodo,elixirInterpolation,@Spell fold
 
 " Defines
 syn keyword elixirDefine              def            nextgroup=elixirFunctionDeclaration    skipwhite skipnl


### PR DESCRIPTION
Enables seeing code samples and spellchecking docs more easily when `g:elixir_use_markdown_for_docs` is set.

![image](https://cloud.githubusercontent.com/assets/628/19747695/6bba0e12-9b9a-11e6-80cd-bbb5f0d744a9.png)
