### PR TITLE
fixes Wrong colour for keyword "length" in keyword list #206

### DIFF
--- a/spec/indent/blocks_spec.rb
+++ b/spec/indent/blocks_spec.rb
@@ -47,7 +47,7 @@ describe 'Indenting blocks' do
   end
 
   it 'guard in function' do
-    expect(<<~EOF).to include_elixir_syntax('elixirKeyword', 'is_atom')
+    expect(<<~EOF).to include_elixir_syntax('elixirKernelFunction', 'is_atom')
     defmodule M do
       def fun(a) when is_atom(a) do
         1

--- a/spec/syntax/guard_spec.rb
+++ b/spec/syntax/guard_spec.rb
@@ -4,14 +4,14 @@ require 'spec_helper'
 
 describe 'Guard syntax' do
   it 'guard in function' do
-    expect(<<~EOF).to include_elixir_syntax('elixirKeyword', 'is_atom')
+    expect(<<~EOF).to include_elixir_syntax('elixirKernelFunction', 'is_atom')
     def fun(a) when is_atom(a) do
     end
     EOF
   end
 
   it 'guard in case' do
-    expect(<<~EOF).to include_elixir_syntax('elixirKeyword', 'is_atom')
+    expect(<<~EOF).to include_elixir_syntax('elixirKernelFunction', 'is_atom')
     case
       a when is_atom(a) -> {:ok, a}
     end
@@ -19,7 +19,7 @@ describe 'Guard syntax' do
   end
 
   it 'does not highlight outside guards' do
-    expect(<<~EOF).not_to include_elixir_syntax('elixirKeyword', 'is_atom')
+    expect(<<~EOF).not_to include_elixir_syntax('elixirKernelFunction', 'is_atom')
       if is_atom(a) do
         {:ok, a}
       end

--- a/spec/syntax/kernel_function_spec.rb
+++ b/spec/syntax/kernel_function_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Kernel function syntax' do
+  it 'kernel function used as an atom key in a keyword list contained in a block' do
+    expect(<<~EOF).not_to include_elixir_syntax('elixirKernelFunction', 'length')
+    do
+      plug Plug.Parsers,
+        parsers: [:urlencoded, :multipart, :json],
+        pass: ["*/*"],
+        json_decoder: Poison,
+        length: 400_000_000
+    EOF
+  end
+
+  it 'kernel function used as a guard' do
+    expect(<<~'EOF').to include_elixir_syntax('elixirKernelFunction', 'length')
+    def hello(name) when length(name) > 20 do
+      IO.puts "hello #{name}, you big boy"
+    end
+    EOF
+  end
+
+  it 'kernel function used in a function body' do
+    expect(<<~'EOF').not_to include_elixir_syntax('elixirKernelFunction', 'length')
+    def say_size(chars) do
+      size = length(chars)
+      IO.puts "you gave me #{size} chars"
+    end
+    EOF
+  end
+
+  it 'kernel function used as top-level' do
+    expect(<<~'EOF').not_to include_elixir_syntax('elixirKernelFunction', 'length')
+    length(chars)
+    EOF
+  end
+end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -22,13 +22,9 @@ syn match elixirKeyword '\(\.\)\@<!\<\(for\|case\|when\|with\|cond\|if\|unless\|
 syn match elixirKeyword '\(\.\)\@<!\<\(exit\|raise\|throw\|after\|rescue\|catch\|else\)\>'
 syn match elixirKeyword '\(\.\)\@<!\<\(quote\|unquote\|super\|spawn\|spawn_link\|spawn_monitor\)\>'
 
-" Functions used on guards
-syn keyword elixirKeyword contained is_atom is_binary is_bitstring is_boolean
-syn keyword elixirKeyword contained is_float is_function is_integer is_list
-syn keyword elixirKeyword contained is_map is_nil is_number is_pid is_port
-syn keyword elixirKeyword contained is_record is_reference is_tuple is_exception
-syn keyword elixirKeyword contained abs bit_size byte_size div elem hd length
-syn keyword elixirKeyword contained map_size node rem round tl trunc tuple_size
+" Kernel functions
+syn match elixirKernelFunction contained containedin=elixirGuard '\<\(is_atom\|is_binary\|is_bitstring\|is_boolean\|is_float\|is_function\|is_integer\|is_list\|is_map\|is_nil\|is_number\|is_pid\|is_port\)\>\([ (]\)\@='
+syn match elixirKernelFunction contained containedin=elixirGuard '\<\(is_record\|is_reference\|is_tuple\|is_exception\|abs\|bit_size\|byte_size\|div\|elem\|hd\|length\|map_size\|node\|rem\|round\|tl\|trunc\|tuple_size\)\>\([ (]\)\@='
 
 syn match elixirGuard '.*when.*' contains=ALLBUT,@elixirNotTop
 
@@ -83,14 +79,14 @@ syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('\)+   end=+
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@elixirStringContained
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('''\)+ end=+^\s*\z1+ skip=+'\|\\\\+  contains=@elixirStringContained
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("""\)+ end=+^\s*\z1+ skip=+"\|\\\\+  contains=@elixirStringContained
-syn region elixirInterpolation matchgroup=elixirInterpolationDelimiter start="#{" end="}" contained contains=ALLBUT,elixirComment,@elixirNotTop
+syn region elixirInterpolation matchgroup=elixirInterpolationDelimiter start="#{" end="}" contained contains=ALLBUT,elixirKernelFunction,elixirComment,@elixirNotTop
 
 syn match elixirAtomInterpolated   ':\("\)\@=' contains=elixirString
 syn match elixirString             "\(\w\)\@<!?\%(\\\(x\d{1,2}\|\h{1,2}\h\@!\>\|0[0-7]{0,2}[0-7]\@!\>\|[^x0MC]\)\|(\\[MC]-)+\w\|[^\s\\]\)"
 
-syn region elixirBlock              matchgroup=elixirBlockDefinition start="\<do\>:\@!" end="\<end\>" contains=ALLBUT,@elixirNotTop fold
-syn region elixirElseBlock          matchgroup=elixirBlockDefinition start="\<else\>:\@!" end="\<end\>" contains=ALLBUT,@elixirNotTop fold
-syn region elixirAnonymousFunction  matchgroup=elixirBlockDefinition start="\<fn\>"     end="\<end\>" contains=ALLBUT,@elixirNotTop fold
+syn region elixirBlock              matchgroup=elixirBlockDefinition start="\<do\>:\@!" end="\<end\>" contains=ALLBUT,elixirKernelFunction,@elixirNotTop fold
+syn region elixirElseBlock          matchgroup=elixirBlockDefinition start="\<else\>:\@!" end="\<end\>" contains=ALLBUT,elixirKernelFunction,@elixirNotTop fold
+syn region elixirAnonymousFunction  matchgroup=elixirBlockDefinition start="\<fn\>"     end="\<end\>" contains=ALLBUT,elixirKernelFunction,@elixirNotTop fold
 
 syn region elixirArguments start="(" end=")" contained contains=elixirOperator,elixirAtom,elixirPseudoVariable,elixirAlias,elixirBoolean,elixirVariable,elixirUnusedVariable,elixirNumber,elixirDocString,elixirAtomInterpolated,elixirRegex,elixirString,elixirStringDelimiter,elixirRegexDelimiter,elixirInterpolationDelimiter,elixirSigilDelimiter
 
@@ -194,6 +190,7 @@ hi def link elixirComment                Comment
 hi def link elixirTodo                   Todo
 hi def link elixirKeyword                Keyword
 hi def link elixirExUnitAssert           Keyword
+hi def link elixirKernelFunction         Keyword
 hi def link elixirOperator               Operator
 hi def link elixirAtom                   Constant
 hi def link elixirPseudoVariable         Constant


### PR DESCRIPTION
fixes Wrong colour for keyword "length" in keyword list #206

Note that this also removes highlighting in some places that I found it
to be useful (e.g. using `is_pid` in a function body) but that can be
discussed in a different PR
