### PR TITLE
add bin/spawn_vim for interactive debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ Copy the contents of each directory in the respective directories inside
 [pathogen]: https://github.com/tpope/vim-pathogen
 [syntastic]: https://github.com/scrooloose/syntastic
 [syntastic-issue-fix]: https://github.com/scrooloose/syntastic/commit/1d19dff701524ebed90a4fbd7c7cd75ab954b79d
+
+## Development
+
+To run the tests you can run `bundle exec rspec`
+
+To spawn an interactive Vim instance with the configs from this repo use `bin/spawn_vim`

--- a/bin/spawn_vim
+++ b/bin/spawn_vim
@@ -1,0 +1,10 @@
+#! /usr/bin/env ruby
+require 'vimrunner'
+dir = File.expand_path('..', __dir__)
+plugin = 'ftdetect/elixir.vim'
+vim = Vimrunner.start_gvim
+vim.add_plugin(dir, plugin)
+vim.edit! "test.ex"
+vim.normal
+
+loop {}


### PR DESCRIPTION
This adds `bin/spawn_vim` which will spawn a new vim instance for playing around in with these configs
