### PR TITLE
fix bug with unused args when function signature spans multiple lines (#196)

### DIFF
--- a/spec/syntax/variable_spec.rb
+++ b/spec/syntax/variable_spec.rb
@@ -19,7 +19,7 @@ describe 'Variable syntax' do
     EOF
   end
 
-  pending 'unused, multiple lines' do
+  it 'unused, multiple lines' do
     expect(<<~EOF).to include_elixir_syntax('elixirUnusedVariable', '_from')
       def handle_call(:pop,
                       _from,
@@ -29,7 +29,15 @@ describe 'Variable syntax' do
     EOF
   end
 
-  pending 'unused in pattern_match' do
+  it 'unused, single char' do
+    expect(<<~EOF).to include_elixir_syntax('elixirUnusedVariable', '_')
+      def call(:pop, _, [h|stack]) do
+        { :reply, h, stack }
+      end
+    EOF
+  end
+
+  it 'unused in pattern_match' do
     str = <<~EOF
     def sign_in(conn, %{
       "data" => %{

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -8,7 +8,7 @@ set cpo&vim
 " syncing starts 2000 lines before top line so docstrings don't screw things up
 syn sync minlines=2000
 
-syn cluster elixirNotTop contains=@elixirRegexSpecial,@elixirStringContained,@elixirDeclaration,elixirTodo,elixirArguments,elixirBlockDefinition
+syn cluster elixirNotTop contains=@elixirRegexSpecial,@elixirStringContained,@elixirDeclaration,elixirTodo,elixirArguments,elixirBlockDefinition,elixirUnusedVariable
 syn cluster elixirRegexSpecial contains=elixirRegexEscape,elixirRegexCharClass,elixirRegexQuantifier,elixirRegexEscapePunctuation
 syn cluster elixirStringContained contains=elixirInterpolation,elixirRegexEscape,elixirRegexCharClass
 syn cluster elixirDeclaration contains=elixirFunctionDeclaration,elixirModuleDeclaration,elixirProtocolDeclaration,elixirImplDeclaration,elixirRecordDeclaration,elixirMacroDeclaration,elixirDelegateDeclaration,elixirOverridableDeclaration,elixirExceptionDeclaration,elixirCallbackDeclaration,elixirStructDeclaration
@@ -37,7 +37,7 @@ syn keyword elixirInclude import require alias use
 syn keyword elixirSelf self
 
 " This unfortunately also matches function names in function calls
-syn match elixirUnusedVariable '\(([^)]*\)\@<=\<_\w*\>'
+syn match elixirUnusedVariable contained '\<_\w*\>'
 
 syn keyword elixirOperator and not or in
 syn match   elixirOperator '!==\|!=\|!'


### PR DESCRIPTION
Addresses #196
