### PR TITLE
Move the indentation rules to autoload functions

### DIFF
--- a/autoload/elixir/indent.vim
+++ b/autoload/elixir/indent.vim
@@ -1,0 +1,208 @@
+let s:NO_COLON_BEFORE = ':\@<!'
+let s:NO_COLON_AFTER = ':\@!'
+let s:ENDING_SYMBOLS = '\]\|}\|)'
+let s:STARTING_SYMBOLS = '\[\|{\|('
+let s:ARROW = '->'
+let s:END_WITH_ARROW = s:ARROW.'$'
+let s:SKIP_SYNTAX = '\%(Comment\|String\)$'
+let s:BLOCK_SKIP = "synIDattr(synID(line('.'),col('.'),1),'name') =~? '".s:SKIP_SYNTAX."'"
+let s:DEF = '^\s*def'
+let s:FN = '\<fn\>'
+let s:MULTILINE_FN = s:FN.'\%(.*end\)\@!'
+let s:BLOCK_START = '\%(\<do\>\|'.s:FN.'\)\>'
+let s:MULTILINE_BLOCK = '\%(\<do\>'.s:NO_COLON_AFTER.'\|'.s:MULTILINE_FN.'\)'
+let s:BLOCK_MIDDLE = '\<\%(else\|match\|elsif\|catch\|after\|rescue\)\>'
+let s:BLOCK_END = 'end'
+let s:STARTS_WITH_PIPELINE = '^\s*|>.*$'
+let s:ENDING_WITH_ASSIGNMENT = '=\s*$'
+let s:INDENT_KEYWORDS = s:NO_COLON_BEFORE.'\%('.s:MULTILINE_BLOCK.'\|'.s:BLOCK_MIDDLE.'\)'
+let s:DEINDENT_KEYWORDS = '^\s*\<\%('.s:BLOCK_END.'\|'.s:BLOCK_MIDDLE.'\)\>'
+let s:PAIR_START = '\<\%('.s:NO_COLON_BEFORE.s:BLOCK_START.'\)\>'.s:NO_COLON_AFTER
+let s:PAIR_MIDDLE = '^\s*\%('.s:BLOCK_MIDDLE.'\)\>'.s:NO_COLON_AFTER.'\zs'
+let s:PAIR_END = '\<\%('.s:NO_COLON_BEFORE.s:BLOCK_END.'\)\>\zs'
+
+function! s:pending_parenthesis(line)
+  if a:line.last.text !~ s:ARROW
+    return elixir#util#count_indentable_symbol_diff(a:line, '(', '\%(end\s*\)\@<!)')
+  end
+endfunction
+
+function! s:pending_square_brackets(line)
+  if a:line.last.text !~ s:ARROW
+    return elixir#util#count_indentable_symbol_diff(a:line, '[', ']')
+  end
+endfunction
+
+function! s:pending_brackets(line)
+  if a:line.last.text !~ s:ARROW
+    return elixir#util#count_indentable_symbol_diff(a:line, '{', '}')
+  end
+endfunction
+
+function! elixir#indent#deindent_case_arrow(ind, line)
+  if get(b:old_ind, 'arrow', 0) > 0
+        \ && (a:line.current.text =~ s:ARROW
+        \ || a:line.current.text =~ s:BLOCK_END)
+    let ind = b:old_ind.arrow
+    let b:old_ind.arrow = 0
+    return ind
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#deindent_ending_symbols(ind, line)
+  if a:line.current.text =~ '^\s*\('.s:ENDING_SYMBOLS.'\)'
+    return a:ind - &sw
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#deindent_keywords(ind, line)
+  if a:line.current.text =~ s:DEINDENT_KEYWORDS
+    let bslnum = searchpair(
+          \ s:PAIR_START,
+          \ s:PAIR_MIDDLE,
+          \ s:PAIR_END,
+          \ 'nbW',
+          \ s:BLOCK_SKIP
+          \ )
+
+    return indent(bslnum)
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#deindent_opened_symbols(ind, line)
+  let s:opened_symbol =
+        \   s:pending_parenthesis(a:line)
+        \ + s:pending_square_brackets(a:line)
+        \ + s:pending_brackets(a:line)
+
+  if s:opened_symbol < 0
+    let ind = get(b:old_ind, 'symbol', a:ind + (s:opened_symbol * &sw))
+    let ind = float2nr(ceil(floor(ind)/&sw)*&sw)
+    return ind <= 0 ? 0 : ind
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_after_pipeline(ind, line)
+  if a:line.last.text =~ s:STARTS_WITH_PIPELINE
+    if empty(substitute(a:line.current.text, ' ', '', 'g'))
+          \ || a:line.current.text =~ s:STARTS_WITH_PIPELINE
+      return indent(a:line.last.num)
+    elseif a:line.last.text !~ s:INDENT_KEYWORDS
+      let ind = b:old_ind.pipeline
+      let b:old_ind.pipeline = 0
+      return ind
+    end
+  end
+
+  return a:ind
+endfunction
+
+function! elixir#indent#indent_assignment(ind, line)
+  if a:line.last.text =~ s:ENDING_WITH_ASSIGNMENT
+    let b:old_ind.pipeline = indent(a:line.last.num) " FIXME: side effect
+    return a:ind + &sw
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_brackets(ind, line)
+  if s:pending_brackets(a:line) > 0
+    return a:ind + &sw
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_case_arrow(ind, line)
+  if a:line.last.text =~ s:END_WITH_ARROW && a:line.last.text !~ '\<fn\>'
+    let b:old_ind.arrow = a:ind
+    return a:ind + &sw
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_ending_symbols(ind, line)
+  if a:line.last.text =~ '^\s*\('.s:ENDING_SYMBOLS.'\)\s*$'
+    return a:ind + &sw
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_keywords(ind, line)
+  if a:line.last.text =~ s:INDENT_KEYWORDS
+    return a:ind + &sw
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_parenthesis(ind, line)
+  if s:pending_parenthesis(a:line) > 0
+        \ && a:line.last.text !~ s:DEF
+        \ && a:line.last.text !~ s:END_WITH_ARROW
+    let b:old_ind.symbol = a:ind
+    return matchend(a:line.last.text, '(')
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_pipeline_assignment(ind, line)
+  if a:line.current.text =~ s:STARTS_WITH_PIPELINE
+        \ && a:line.last.text =~ '^[^=]\+=.\+$'
+    let b:old_ind.pipeline = indent(a:line.last.num)
+    " if line starts with pipeline
+    " and last line is an attribution
+    " indents pipeline in same level as attribution
+    return match(a:line.last.text, '=\s*\zs[^ ]')
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_pipeline_continuation(ind, line)
+  if a:line.last.text =~ s:STARTS_WITH_PIPELINE
+        \ && a:line.current.text =~ s:STARTS_WITH_PIPELINE
+    return indent(a:line.last.num)
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#indent_square_brackets(ind, line)
+  if s:pending_square_brackets(a:line) > 0
+    if a:line.last.text =~ '[\s*$'
+      return a:ind + &sw
+    else
+      " if start symbol is followed by a character, indent based on the
+      " whitespace after the symbol, otherwise use the default shiftwidth
+      " Avoid negative indentation index
+      return matchend(a:line.last.text, '[\s*')
+    end
+  else
+    return a:ind
+  end
+endfunction
+
+function! elixir#indent#deindent_case_arrow(ind, line)
+  if get(b:old_ind, 'arrow', 0) > 0
+        \ && (a:line.current.text =~ s:ARROW
+        \ || a:line.current.text =~ s:BLOCK_END)
+    let ind = b:old_ind.arrow
+    let b:old_ind.arrow = 0
+    return ind
+  else
+    return a:ind
+  end
+endfunction

--- a/autoload/elixir/util.vim
+++ b/autoload/elixir/util.vim
@@ -1,0 +1,48 @@
+let s:SKIP_SYNTAX = '\%(Comment\|String\)$'
+let s:BLOCK_SKIP = "synIDattr(synID(line('.'),col('.'),1),'name') =~? '".s:SKIP_SYNTAX."'"
+
+function! elixir#util#is_indentable_at(line, col)
+  " TODO: Remove these 2 lines
+  " I don't know why, but for the test on spec/indent/lists_spec.rb:24.
+  " Vim is making some mess on parsing the syntax of 'end', it is being
+  " recognized as 'elixirString' when should be recognized as 'elixirBlock'.
+  call synID(a:line, a:col, 1)
+  " This forces vim to sync the syntax.
+  syntax sync fromstart
+
+  return synIDattr(synID(a:line, a:col, 1), "name")
+        \ !~ s:SKIP_SYNTAX
+endfunction
+
+function! elixir#util#is_indentable_match(line, pattern)
+  return elixir#util#is_indentable_at(a:line, match(getline(a:line), a:pattern))
+endfunction
+
+function! elixir#util#count_indentable_symbol_diff(line, open, close)
+  if elixir#util#is_indentable_match(a:line.last.num, a:open)
+        \ && elixir#util#is_indentable_match(a:line.last.num, a:close)
+    return
+          \   s:match_count(a:line.last.text, a:open)
+          \ - s:match_count(a:line.last.text, a:close)
+  else
+    return 0
+  end
+endfunction
+
+function! s:match_count(string, pattern)
+  let size = strlen(a:string)
+  let index = 0
+  let counter = 0
+
+  while index < size
+    let index = match(a:string, a:pattern, index)
+    if index >= 0
+      let index += 1
+      let counter +=1
+    else
+      break
+    end
+  endwhile
+
+  return counter
+endfunction

--- a/indent/elixir.vim
+++ b/indent/elixir.vim
@@ -1,288 +1,61 @@
-if exists("b:did_indent")
+setlocal nosmartindent
+setlocal indentexpr=elixir#indent()
+setlocal indentkeys+=0),0],0=\|>,=->
+setlocal indentkeys+=0=end,0=else,0=match,0=elsif,0=catch,0=after,0=rescue
+
+if exists("b:did_indent") || exists("*elixir#indent")
   finish
 end
 let b:did_indent = 1
 
-setlocal nosmartindent
-
-setlocal indentexpr=GetElixirIndent()
-setlocal indentkeys+=0),0],0=end,0=else,0=match,0=elsif,0=catch,0=after,0=rescue,0=\|>,=->
-
-if exists("*GetElixirIndent")
-  finish
-end
-
 let s:cpo_save = &cpo
 set cpo&vim
 
-let s:no_colon_before = ':\@<!'
-let s:no_colon_after = ':\@!'
-let s:ending_symbols = '\]\|}\|)'
-let s:starting_symbols = '\[\|{\|('
-let s:arrow = '->'
-let s:end_with_arrow = s:arrow.'$'
-let s:skip_syntax = '\%(Comment\|String\)$'
-let s:block_skip = "synIDattr(synID(line('.'),col('.'),1),'name') =~? '".s:skip_syntax."'"
-let s:fn = '\<fn\>'
-let s:multiline_fn = s:fn.'\%(.*end\)\@!'
-let s:block_start = '\%(\<do\>\|'.s:fn.'\)\>'
-let s:multiline_block = '\%(\<do\>'.s:no_colon_after.'\|'.s:multiline_fn.'\)'
-let s:block_middle = '\<\%(else\|match\|elsif\|catch\|after\|rescue\)\>'
-let s:block_end = 'end'
-let s:starts_with_pipeline = '^\s*|>.*$'
-let s:ending_with_assignment = '=\s*$'
-
-let s:indent_keywords = s:no_colon_before.'\%('.s:multiline_block.'\|'.s:block_middle.'\)'
-let s:deindent_keywords = '^\s*\<\%('.s:block_end.'\|'.s:block_middle.'\)\>'
-
-let s:pair_start = '\<\%('.s:no_colon_before.s:block_start.'\)\>'.s:no_colon_after
-let s:pair_middle = '^\s*\%('.s:block_middle.'\)\>'.s:no_colon_after.'\zs'
-let s:pair_end = '\<\%('.s:no_colon_before.s:block_end.'\)\>\zs'
-
-function! GetElixirIndent()
-  call s:build_data()
+function! elixir#indent()
+  " initiates the `old_ind` dictionary
   let b:old_ind = get(b:, 'old_ind', {})
+  " initialtes the `line` dictionary
+  let line = s:build_line(v:lnum)
 
-  if s:last_line_ref == 0
-    " At the start of the file use zero indent.
+  if line.last.num == 0
+    " Reset `old_ind` dictionary at the beginning of the file
     let b:old_ind = {}
+    " At the start of the file use zero indent.
     return 0
-  elseif !s:is_indentable_at(s:current_line_ref, 1)
-    " Current syntax is not indentable, keep last line indentation
-    return indent(s:last_line_ref)
+  elseif !elixir#util#is_indentable_at(line.current.num, 1)
+    " Keep last line indentation if the current line does not have an
+    " indentable syntax
+    return indent(line.last.num)
   else
-    let ind = indent(s:last_line_ref)
-    let ind = s:deindent_case_arrow(ind)
-    let ind = s:indent_parenthesis(ind)
-    let ind = s:indent_square_brackets(ind)
-    let ind = s:indent_brackets(ind)
-    let ind = s:deindent_opened_symbols(ind)
-    let ind = s:indent_pipeline_assignment(ind)
-    let ind = s:indent_pipeline_continuation(ind)
-    let ind = s:indent_after_pipeline(ind)
-    let ind = s:indent_assignment(ind)
-    let ind = s:indent_ending_symbols(ind)
-    let ind = s:indent_keywords(ind)
-    let ind = s:deindent_keywords(ind)
-    let ind = s:deindent_ending_symbols(ind)
-    let ind = s:indent_case_arrow(ind)
+    " Calculates the indenation level based on the rules
+    " All the rules are defined in `autoload/indent.vim`
+    let ind = indent(line.last.num)
+    let ind = elixir#indent#deindent_case_arrow(ind, line)
+    let ind = elixir#indent#indent_parenthesis(ind, line)
+    let ind = elixir#indent#indent_square_brackets(ind, line)
+    let ind = elixir#indent#indent_brackets(ind, line)
+    let ind = elixir#indent#deindent_opened_symbols(ind, line)
+    let ind = elixir#indent#indent_pipeline_assignment(ind, line)
+    let ind = elixir#indent#indent_pipeline_continuation(ind, line)
+    let ind = elixir#indent#indent_after_pipeline(ind, line)
+    let ind = elixir#indent#indent_assignment(ind, line)
+    let ind = elixir#indent#indent_ending_symbols(ind, line)
+    let ind = elixir#indent#indent_keywords(ind, line)
+    let ind = elixir#indent#deindent_keywords(ind, line)
+    let ind = elixir#indent#deindent_ending_symbols(ind, line)
+    let ind = elixir#indent#indent_case_arrow(ind, line)
     return ind
   end
 endfunction
 
-function! s:build_data()
-  let s:current_line_ref = v:lnum
-  let s:last_line_ref = prevnonblank(s:current_line_ref - 1)
-  let s:current_line = getline(s:current_line_ref)
-  let s:last_line = getline(s:last_line_ref)
+function! s:build_line(line)
+  let line = { 'current': {}, 'last': {} }
+  let line.current.num = a:line
+  let line.current.text = getline(line.current.num)
+  let line.last.num = prevnonblank(line.current.num - 1)
+  let line.last.text = getline(line.last.num)
 
-  if s:last_line !~ s:arrow
-    let s:pending_parenthesis = s:count_indentable_symbol_diff('(', '\%(end\s*\)\@<!)')
-    let s:pending_square_brackets = s:count_indentable_symbol_diff('[', ']')
-    let s:pending_brackets = s:count_indentable_symbol_diff('{', '}')
-  end
-endfunction
-
-function! s:count_indentable_symbol_diff(open, close)
-  if s:is_indentable_match(s:last_line_ref, a:open)
-        \ && s:is_indentable_match(s:last_line_ref, a:close)
-    return
-          \   s:count_pattern(s:last_line, a:open)
-          \ - s:count_pattern(s:last_line, a:close)
-  else
-    return 0
-  end
-endfunction
-
-function! s:count_pattern(string, pattern)
-  let size = strlen(a:string)
-  let index = 0
-  let counter = 0
-
-  while index < size
-    let index = match(a:string, a:pattern, index)
-    if index >= 0
-      let index += 1
-      let counter +=1
-    else
-      break
-    end
-  endwhile
-
-  return counter
-endfunction
-
-function! s:is_indentable_at(line, col)
-  " TODO: Remove these 2 lines
-  " I don't know why, but for the test on spec/indent/lists_spec.rb:24.
-  " Vim is making some mess on parsing the syntax of 'end', it is being
-  " recognized as 'elixirString' when should be recognized as 'elixirBlock'.
-  call synID(a:line, a:col, 1)
-  " This forces vim to sync the syntax.
-  syntax sync fromstart
-
-  return synIDattr(synID(a:line, a:col, 1), "name")
-        \ !~ s:skip_syntax
-endfunction
-
-function! s:is_indentable_match(line, pattern)
-  return s:is_indentable_at(a:line, match(getline(a:line), a:pattern))
-endfunction
-
-function! s:indent_parenthesis(ind)
-  if s:pending_parenthesis > 0
-        \ && s:last_line !~ '^\s*def'
-        \ && s:last_line !~ s:end_with_arrow
-    let b:old_ind.symbol = a:ind
-    return matchend(s:last_line, '(')
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:indent_square_brackets(ind)
-  if s:pending_square_brackets > 0
-    if s:last_line =~ '[\s*$'
-      return a:ind + &sw
-    else
-      " if start symbol is followed by a character, indent based on the
-      " whitespace after the symbol, otherwise use the default shiftwidth
-      " Avoid negative indentation index
-      return matchend(s:last_line, '[\s*')
-    end
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:indent_brackets(ind)
-  if s:pending_brackets > 0
-    return a:ind + &sw
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:deindent_opened_symbols(ind)
-  let s:opened_symbol =
-        \   s:pending_parenthesis
-        \ + s:pending_square_brackets
-        \ + s:pending_brackets
-
-  if s:opened_symbol < 0
-    let ind = get(b:old_ind, 'symbol', a:ind + (s:opened_symbol * &sw))
-    let ind = float2nr(ceil(floor(ind)/&sw)*&sw)
-    return ind <= 0 ? 0 : ind
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:indent_pipeline_assignment(ind)
-  if s:current_line =~ s:starts_with_pipeline
-        \ && s:last_line =~ '^[^=]\+=.\+$'
-    let b:old_ind.pipeline = indent(s:last_line_ref)
-    " if line starts with pipeline
-    " and last line is an attribution
-    " indents pipeline in same level as attribution
-    return match(s:last_line, '=\s*\zs[^ ]')
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:indent_pipeline_continuation(ind)
-  if s:last_line =~ s:starts_with_pipeline
-        \ && s:current_line =~ s:starts_with_pipeline
-    return indent(s:last_line_ref)
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:indent_after_pipeline(ind)
-  if s:last_line =~ s:starts_with_pipeline
-    if empty(substitute(s:current_line, ' ', '', 'g'))
-          \ || s:current_line =~ s:starts_with_pipeline
-      return indent(s:last_line_ref)
-    elseif s:last_line !~ s:indent_keywords
-      let ind = b:old_ind.pipeline
-      let b:old_ind.pipeline = 0
-      return ind
-    end
-  end
-
-  return a:ind
-endfunction
-
-function! s:indent_assignment(ind)
-  if s:last_line =~ s:ending_with_assignment
-    let b:old_ind.pipeline = indent(s:last_line_ref) " FIXME: side effect
-    return a:ind + &sw
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:indent_ending_symbols(ind)
-  if s:last_line =~ '^\s*\('.s:ending_symbols.'\)\s*$'
-    return a:ind + &sw
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:indent_keywords(ind)
-  if s:last_line =~ s:indent_keywords
-    return a:ind + &sw
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:deindent_keywords(ind)
-  if s:current_line =~ s:deindent_keywords
-    let bslnum = searchpair(
-          \ s:pair_start,
-          \ s:pair_middle,
-          \ s:pair_end,
-          \ 'nbW',
-          \ s:block_skip
-          \ )
-
-    return indent(bslnum)
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:deindent_ending_symbols(ind)
-  if s:current_line =~ '^\s*\('.s:ending_symbols.'\)'
-    return a:ind - &sw
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:deindent_case_arrow(ind)
-  if get(b:old_ind, 'arrow', 0) > 0
-        \ && (s:current_line =~ s:arrow
-        \ || s:current_line =~ s:block_end)
-    let ind = b:old_ind.arrow
-    let b:old_ind.arrow = 0
-    return ind
-  else
-    return a:ind
-  end
-endfunction
-
-function! s:indent_case_arrow(ind)
-  if s:last_line =~ s:end_with_arrow && s:last_line !~ '\<fn\>'
-    let b:old_ind.arrow = a:ind
-    return a:ind + &sw
-  else
-    return a:ind
-  end
+  return line
 endfunction
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
The main reason of this is try to simplify the rules definition.

- Simplify the `indent/elixir.vim` moving all the indentation rules to
`autoload/indent.vim`. The indent script is responsible now for call the
rules, not define them.
- Rename `GetElixirIndent` to `elixir#indent`.
- Use constants with SCREAM_CASE.
- Each rule function now receives the current indentation and a line
dictionary, which contains the current and last lines number and texts.

@jbodah can you gimme your 2 cents here?