### PR TITLE
rspec: add support for `, focus: true` tags

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -167,4 +167,8 @@ end
 
 RSpec.configure do |config|
   config.order = :random
+
+  # Run a single spec by adding the `focus: true` option
+  config.filter_run_including focus: true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
This allows us to quickly focus a test with the `focus: true` tag e.g.

```rb
  it '`atom:` style keyword used as an atom', focus: true do
    KEYWORDS.each do |kw|
      expect(<<~EOF).to include_elixir_syntax('elixirAtom', kw), "expected #{kw} to be an elixirAtom"
      defmodule XmlElement do
        require Record
        import Record, only: [#{kw}: 2, extract: 2]
      end
      EOF
    end
  end
```

Here's a handy vim snippet for adding/removing them: 

```vim
" rspec focus
nnoremap <leader>ff 0/['"] do[\n]<CR>a, focus: true<Esc>:w<CR>:nohlsearch<CR>
nnoremap <leader>uf 0:s/, focus: true//<CR>:w<CR>
```