### PR TITLE
fix poor indent performance on files over 1k lines

### DIFF
--- a/autoload/elixir/util.vim
+++ b/autoload/elixir/util.vim
@@ -7,8 +7,9 @@ function! elixir#util#is_indentable_at(line, col)
   " Vim is making some mess on parsing the syntax of 'end', it is being
   " recognized as 'elixirString' when should be recognized as 'elixirBlock'.
   call synID(a:line, a:col, 1)
-  " This forces vim to sync the syntax.
-  syntax sync fromstart
+  " This forces vim to sync the syntax. Using fromstart is very slow on files
+  " over 1k lines
+  syntax sync minlines=20 maxlines=150
 
   return synIDattr(synID(a:line, a:col, 1), "name")
         \ !~ s:SKIP_SYNTAX


### PR DESCRIPTION
While editing very big file (2_500 lines, exunit test file with lots of cases), vim starts to crawl to death. I literally need to wait a few seconds on pressing Enter each time.

Profiling shows that:
```
FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
  155              6.407817  elixir#util#is_indentable_at()
  140              0.008775  <SNR>92_match_count()
   13   6.442832   0.005395  elixir#indent()
```

Turning sync off makes vim run at expected speed. In order to offer compromise between correct syntax detection and speed - minlines/maxlines are used.