### PR TITLE
Skip vim folds when indenting

### DIFF
--- a/autoload/elixir/util.vim
+++ b/autoload/elixir/util.vim
@@ -1,4 +1,4 @@
-let s:SKIP_SYNTAX = '\%(Comment\|String\)$'
+let s:SKIP_SYNTAX = '\%(Comment\|String\|elixirFold\)$'
 let s:BLOCK_SKIP = "synIDattr(synID(line('.'),col('.'),1),'name') =~? '".s:SKIP_SYNTAX."'"
 
 function! elixir#util#is_indentable_at(line, col)

--- a/autoload/elixir/util.vim
+++ b/autoload/elixir/util.vim
@@ -7,8 +7,9 @@ function! elixir#util#is_indentable_at(line, col)
   " Vim is making some mess on parsing the syntax of 'end', it is being
   " recognized as 'elixirString' when should be recognized as 'elixirBlock'.
   call synID(a:line, a:col, 1)
-  " This forces vim to sync the syntax.
-  syntax sync fromstart
+  " This forces vim to sync the syntax. Using fromstart is very slow on files
+  " over 1k lines
+  syntax sync minlines=20 maxlines=150
 
   return synIDattr(synID(a:line, a:col, 1), "name")
         \ !~ s:SKIP_SYNTAX

--- a/autoload/elixir/util.vim
+++ b/autoload/elixir/util.vim
@@ -2,6 +2,9 @@ let s:SKIP_SYNTAX = '\%(Comment\|String\)$'
 let s:BLOCK_SKIP = "synIDattr(synID(line('.'),col('.'),1),'name') =~? '".s:SKIP_SYNTAX."'"
 
 function! elixir#util#is_indentable_at(line, col)
+  if a:col == -1 " skip synID lookup for not found match
+	  return 1
+  end
   " TODO: Remove these 2 lines
   " I don't know why, but for the test on spec/indent/lists_spec.rb:24.
   " Vim is making some mess on parsing the syntax of 'end', it is being
@@ -15,13 +18,13 @@ function! elixir#util#is_indentable_at(line, col)
         \ !~ s:SKIP_SYNTAX
 endfunction
 
-function! elixir#util#is_indentable_match(line, pattern)
-  return elixir#util#is_indentable_at(a:line, match(getline(a:line), a:pattern))
+function! elixir#util#is_indentable_match(line, line_text, pattern)
+  return elixir#util#is_indentable_at(a:line, match(a:line_text, a:pattern))
 endfunction
 
 function! elixir#util#count_indentable_symbol_diff(line, open, close)
-  if elixir#util#is_indentable_match(a:line.last.num, a:open)
-        \ && elixir#util#is_indentable_match(a:line.last.num, a:close)
+  if elixir#util#is_indentable_match(a:line.last.num, a:line.last.text, a:open)
+        \ && elixir#util#is_indentable_match(a:line.last.num, a:line.last.text, a:close)
     return
           \   s:match_count(a:line.last.text, a:open)
           \ - s:match_count(a:line.last.text, a:close)

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -16,6 +16,9 @@ syn cluster elixirDeclaration contains=elixirFunctionDeclaration,elixirModuleDec
 syn match elixirComment '#.*' contains=elixirTodo,@Spell
 syn keyword elixirTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
 
+syn match elixirFold "# {{{"
+syn match elixirFold "# }}}"
+
 syn match elixirId '\<[_a-zA-Z]\w*[!?]\?\>'
 
 syn match elixirKeyword '\(\.\)\@<!\<\(for\|case\|when\|with\|cond\|if\|unless\|try\|receive\|send\)\>'
@@ -215,6 +218,7 @@ hi def link elixirStringDelimiter        Delimiter
 hi def link elixirRegexDelimiter         Delimiter
 hi def link elixirInterpolationDelimiter Delimiter
 hi def link elixirSigilDelimiter         Delimiter
+hi def link elixirFold                   Comment
 
 let b:current_syntax = "elixir"
 


### PR DESCRIPTION
using vim in foldmethod=marker mode causes problems with code

```
def foo() do # {{{
  bar()
end # }}}
```

pressing `O` on line `bar()` creates wrong indent because of {{{ mistakenly taken to be part of tuple.

```
def foo() do # {{{
  bar()
end # }}}
```

specifically mark them as `elixirFold` syntax group and skip them when detecting indent level.