### PR TITLE
`elixirDocString`'s own their ends.

### DIFF
--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -84,6 +84,21 @@ describe 'documentation syntax' do
       expect(ex).to include_elixir_syntax('elixirDocTest',   '2, 4, 6')
     end
 
+    it 'doctest finishes when not followed by blank line' do
+      ex = <<~'EOF'
+      @doc """
+      doctest
+
+      iex> 1 + 2
+      3
+      """
+      def some_fun(x), do: x
+      EOF
+      expect(ex).to include_elixir_syntax('elixirDocString', 'doctest')
+      expect(ex).to include_elixir_syntax('elixirDocTest',   '1 + 2')
+      expect(ex).to include_elixir_syntax('elixirDefine',    'def')
+    end
+
     it 'doc with inline code' do
       ex = <<~'EOF'
       @doc """

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -127,9 +127,9 @@ syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\
 syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S\["                  end="\]"  skip="\\\\\|\\\]"  contains=@elixirDocStringContained fold
 syn region elixirDocString matchgroup=elixirSigilDelimiter  start="\%(@\w*doc\s\+\)\@<=\~S("                   end=")"   skip="\\\\\|\\)"   contains=@elixirDocStringContained fold
 syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("\)+                 end=+\z1+ skip=+\\\\\|\\\z1+  contains=@markdown,@Spell
-syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+               end=+\z1+ contains=@elixirDocStringContained fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\)+ end=+\z1+ skip=+\\'+ contains=@elixirDocStringContained fold
-syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z("""\)+ end=+\z1+ skip=+\\"+ contains=@elixirDocStringContained fold
+syn region elixirDocString matchgroup=elixirStringDelimiter start=+\%(@\w*doc\s\+\)\@<=\z("""\)+               end=+\z1+ contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z('''\)+ end=+\z1+ skip=+\\'+ contains=@elixirDocStringContained fold keepend
+syn region elixirDocString matchgroup=elixirSigilDelimiter  start=+\%(@\w*doc\s\+\)\@<=\~[Ss]\z("""\)+ end=+\z1+ skip=+\\"+ contains=@elixirDocStringContained fold keepend
 
 " Defines
 syn match elixirDefine              '\<def\>\(:\)\@!'             nextgroup=elixirFunctionDeclaration    skipwhite skipnl


### PR DESCRIPTION
This prevents doc tests leaking past the end of the docstring.

Fixes #230