### PR TITLE
highlight doctest macro

### DIFF
--- a/spec/syntax/exunit_spec.rb
+++ b/spec/syntax/exunit_spec.rb
@@ -163,4 +163,12 @@ describe 'ExUnit syntax' do
     end
     EOF
   end
+
+  it 'doctest' do
+    expect(<<~EOF).to include_elixir_syntax('elixirExUnitMacro', 'doctest')
+    module MyTest do
+      doctest MyModule
+    end
+    EOF
+  end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -161,7 +161,7 @@ syn match  elixirExceptionDeclaration   "[^[:space:];#<]\+"        contained con
 syn match  elixirCallbackDeclaration    "[^[:space:];#<,()\[\]]\+" contained contains=elixirFunctionDeclaration             skipwhite skipnl
 
 " ExUnit
-syn match  elixirExUnitMacro "\(^\s*\)\@<=\<\(test\|describe\|setup\|setup_all\|on_exit\)\>"
+syn match  elixirExUnitMacro "\(^\s*\)\@<=\<\(test\|describe\|setup\|setup_all\|on_exit\|doctest\)\>"
 syn match  elixirExUnitAssert "\(^\s*\)\@<=\<\(assert\|assert_in_delta\|assert_raise\|assert_receive\|assert_received\|catch_error\)\>"
 syn match  elixirExUnitAssert "\(^\s*\)\@<=\<\(catch_exit\|catch_throw\|flunk\|refute\|refute_in_delta\|refute_receive\|refute_received\)\>"
 


### PR DESCRIPTION
ExUnit also has the macro doctest
http://elixir-lang.org/docs/stable/ex_unit/ExUnit.DocTest.html#doctest/2

This PR adds it to the ExUnit macro syntax group