### PR TITLE
Fix heredoc syntax highlighting

### DIFF
--- a/spec/syntax/strings_spec.rb
+++ b/spec/syntax/strings_spec.rb
@@ -55,5 +55,21 @@ describe 'String syntax' do
       end
       EOF
     end
+
+    it 'correctly terminates heredocs with no spaces at the start of the line' do
+      expect(<<~'EOF'.gsub(/^\s+/, '')).to include_elixir_syntax('elixirAtom', ':bar')
+      """
+      foo
+      """
+      :bar
+      EOF
+
+      expect(<<~'EOF'.gsub(/^\s+/, '')).to include_elixir_syntax('elixirAtom', ':bar')
+      '''
+      foo
+      '''
+      :bar
+      EOF
+    end
   end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -77,8 +77,8 @@ syn region elixirRegex matchgroup=elixirRegexDelimiter start="%r/" end="/[uiomxf
 
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@elixirStringContained
 syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("\)+   end=+\z1+ skip=+\\\\\|\\\z1+  contains=@elixirStringContained
-syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('''\)+ end=+^\s*\z1+ skip=+'\|\\\\+  contains=@elixirStringContained
-syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("""\)+ end=+^\s*\z1+ skip=+"\|\\\\+  contains=@elixirStringContained
+syn region elixirString  matchgroup=elixirStringDelimiter start=+\z('''\)+ end=+^\s*\z1+ contains=@elixirStringContained
+syn region elixirString  matchgroup=elixirStringDelimiter start=+\z("""\)+ end=+^\s*\z1+ contains=@elixirStringContained
 syn region elixirInterpolation matchgroup=elixirInterpolationDelimiter start="#{" end="}" contained contains=ALLBUT,elixirKernelFunction,elixirComment,@elixirNotTop
 
 syn match elixirAtomInterpolated   ':\("\)\@=' contains=elixirString


### PR DESCRIPTION
Fixes #239.

Heredocs with a closing ''' or """ at the start of the line (with no preceeding
spaces) were being skipped because of the skip rule. Removing the skip rules
fixes the bug.

I wasn't able to get the tests to run on my machine as it seems to be looking for gVim which I don't have on OS X and changing it to just start Vim resulted in it not being able to find Vim. I also tried running them on an Ubuntu VM (again, without gVim as it's headless) but it seems to still need an X server. I think they should pass with the change (and fail without the fix) but it'd be good to check if someone has the test environment set up correctly.