### PR TITLE
fix bin/spawn_vim to not immediately kill the server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 ruby '2.3.1'
 
 gem 'rspec'
-gem 'vimrunner'
+gem 'vimrunner', github: 'AndrewRadev/vimrunner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: git://github.com/AndrewRadev/vimrunner.git
+  revision: 2a5bb5fa6637e74796d7a943b338828453b18b0b
+  specs:
+    vimrunner (0.3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -15,17 +21,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    vimrunner (0.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   rspec
-  vimrunner
+  vimrunner!
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/bin/spawn_vim
+++ b/bin/spawn_vim
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+require 'bundler/setup'
 require 'vimrunner'
 dir = File.expand_path('..', __dir__)
 plugin = 'ftdetect/elixir.vim'
@@ -6,3 +7,5 @@ vim = Vimrunner.start_gvim
 vim.add_plugin(dir, plugin)
 vim.edit! "test.ex"
 vim.normal
+
+Process.wait vim.server.pid


### PR DESCRIPTION
This change causes `vimrunner` to wait until you either ctrl-c the
server or close the vim window before exiting