### PR TITLE
Add an optional debug mode for the indentation

### DIFF
--- a/indent/elixir.vim
+++ b/indent/elixir.vim
@@ -30,22 +30,37 @@ function! elixir#indent()
     " Calculates the indenation level based on the rules
     " All the rules are defined in `autoload/elixir/indent.vim`
     let ind = indent(line.last.num)
-    let ind = elixir#indent#deindent_case_arrow(ind, line)
-    let ind = elixir#indent#indent_parenthesis(ind, line)
-    let ind = elixir#indent#indent_square_brackets(ind, line)
-    let ind = elixir#indent#indent_brackets(ind, line)
-    let ind = elixir#indent#deindent_opened_symbols(ind, line)
-    let ind = elixir#indent#indent_pipeline_assignment(ind, line)
-    let ind = elixir#indent#indent_pipeline_continuation(ind, line)
-    let ind = elixir#indent#indent_after_pipeline(ind, line)
-    let ind = elixir#indent#indent_assignment(ind, line)
-    let ind = elixir#indent#indent_ending_symbols(ind, line)
-    let ind = elixir#indent#indent_keywords(ind, line)
-    let ind = elixir#indent#deindent_keywords(ind, line)
-    let ind = elixir#indent#deindent_ending_symbols(ind, line)
-    let ind = elixir#indent#indent_case_arrow(ind, line)
-    let ind = elixir#indent#indent_ecto_queries(ind, line)
+    call s:debug('>>> initial = ' . ind)
+    let ind = s:indent('deindent_case_arrow', ind, line)
+    let ind = s:indent('indent_parenthesis', ind, line)
+    let ind = s:indent('indent_square_brackets', ind, line)
+    let ind = s:indent('indent_brackets', ind, line)
+    let ind = s:indent('deindent_opened_symbols', ind, line)
+    let ind = s:indent('indent_pipeline_assignment', ind, line)
+    let ind = s:indent('indent_pipeline_continuation', ind, line)
+    let ind = s:indent('indent_after_pipeline', ind, line)
+    let ind = s:indent('indent_assignment', ind, line)
+    let ind = s:indent('indent_ending_symbols', ind, line)
+    let ind = s:indent('indent_keywords', ind, line)
+    let ind = s:indent('deindent_keywords', ind, line)
+    let ind = s:indent('deindent_ending_symbols', ind, line)
+    let ind = s:indent('indent_case_arrow', ind, line)
+    let ind = s:indent('indent_ecto_queries', ind, line)
+    call s:debug('<<< final = ' . ind)
     return ind
+  end
+endfunction
+
+function s:indent(rule, ind, line)
+  let Fn = function('elixir#indent#'.a:rule)
+  let ind = Fn(a:ind, a:line)
+  call s:debug(a:rule . ' = ' . ind)
+  return ind
+endfunction
+
+function s:debug(message)
+  if get(g:, 'elixir_indent_debug', 0)
+    echom a:message
   end
 endfunction
 


### PR DESCRIPTION
Now it's possible to see the value of each indentation rule while
indenting a file if the `g:elixir_indent_debug` is set to 1.

Fixes #251 

/cc @jbodah wdyt?