### PR TITLE
indent: clear pipeline indentation after blank new line

### DIFF
--- a/autoload/elixir/util.vim
+++ b/autoload/elixir/util.vim
@@ -50,3 +50,7 @@ function! s:match_count(string, pattern)
 
   return counter
 endfunction
+
+function elixir#util#is_blank(string)
+  return a:string =~ '^\s*$'
+endfunction

--- a/indent/elixir.vim
+++ b/indent/elixir.vim
@@ -25,7 +25,7 @@ function! elixir#indent()
   elseif !s:is_indentable_line(line)
     " Keep last line indentation if the current line does not have an
     " indentable syntax
-    return indent(line.last.num)
+    return indent(line.last_non_blank.num)
   else
     " Calculates the indenation level based on the rules
     " All the rules are defined in `autoload/elixir/indent.vim`
@@ -65,7 +65,7 @@ function s:debug(message)
 endfunction
 
 function! s:is_beginning_of_file(line)
-  return a:line.last.num == 0
+  return a:line.last_non_blank.num == 0
 endfunction
 
 function! s:is_indentable_line(line)
@@ -73,13 +73,19 @@ function! s:is_indentable_line(line)
 endfunction
 
 function! s:build_line(line)
-  let line = { 'current': {}, 'last': {} }
-  let line.current.num = a:line
-  let line.current.text = getline(line.current.num)
-  let line.last.num = prevnonblank(line.current.num - 1)
-  let line.last.text = getline(line.last.num)
+  let line = { 'current': {}, 'last': {}, 'last_non_blank': {} }
+  let line.current = s:new_line(a:line)
+  let line.last = s:new_line(line.current.num - 1)
+  let line.last_non_blank = s:new_line(prevnonblank(line.current.num - 1))
 
   return line
+endfunction
+
+function! s:new_line(num)
+  return {
+        \ "num": a:num,
+        \ "text": getline(a:num)
+        \ }
 endfunction
 
 let &cpo = s:cpo_save

--- a/spec/indent/pipeline_spec.rb
+++ b/spec/indent/pipeline_spec.rb
@@ -119,4 +119,36 @@ describe 'Indenting pipeline' do
       EOF
     end
   end
+
+  it 'resets the indent after a blank new line' do
+    expect(<<~EOF).to be_elixir_indentation
+      upcased_names = names
+                      |> Enum.map(fn name ->
+                        String.upcase(name)
+                      end)
+
+      IO.inspect names
+    EOF
+  end
+
+  it 'resets the indent after a blank line pt. 2' do
+    expect(<<~EOF).to be_elixir_indentation
+      upcased_names = names
+                      |> Enum.map(fn name ->
+                        String.upcase(name) end)
+
+      IO.inspect names
+    EOF
+  end
+
+  it 'keeps indent after a blank if current starts with pipe' do
+    expect(<<~EOF).to be_elixir_indentation
+      upcased_names = names
+                      |> Enum.map(fn name ->
+                        String.upcase(name)
+                      end)
+
+                      |> do_stuff
+    EOF
+  end
 end


### PR DESCRIPTION
Don't have a ton of time to clean this up at the moment, but here's the
result of a quick hack session. I think something like
`line.last`, `line.last_non_blank`, and `line.current` might make more
sense

* fixes #227