### PR TITLE
upgrade vimrunner

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    vimrunner (0.3.2)
+    vimrunner (0.3.3)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
* This incorporates changes which affect bin/spawn_vim and keep it from
being killed immediately