### PR TITLE
indent: skip strings/comments when checking for open-brace indentation

### DIFF
--- a/autoload/elixir/indent.vim
+++ b/autoload/elixir/indent.vim
@@ -1,7 +1,6 @@
 let s:NO_COLON_BEFORE = ':\@<!'
 let s:NO_COLON_AFTER = ':\@!'
 let s:ENDING_SYMBOLS = '\]\|}\|)'
-let s:STARTING_SYMBOLS = '\[\|{\|('
 let s:ARROW = '->'
 let s:END_WITH_ARROW = s:ARROW.'$'
 let s:SKIP_SYNTAX = '\%(Comment\|String\)$'

--- a/autoload/elixir/util.vim
+++ b/autoload/elixir/util.vim
@@ -26,23 +26,25 @@ function! elixir#util#count_indentable_symbol_diff(line, open, close)
   if elixir#util#is_indentable_match(a:line, a:open)
         \ && elixir#util#is_indentable_match(a:line, a:close)
     return
-          \   s:match_count(a:line.text, a:open)
-          \ - s:match_count(a:line.text, a:close)
+          \   s:match_count(a:line, a:open)
+          \ - s:match_count(a:line, a:close)
   else
     return 0
   end
 endfunction
 
-function! s:match_count(string, pattern)
-  let size = strlen(a:string)
+function! s:match_count(line, pattern)
+  let size = strlen(a:line.text)
   let index = 0
   let counter = 0
 
   while index < size
-    let index = match(a:string, a:pattern, index)
+    let index = match(a:line.text, a:pattern, index)
     if index >= 0
       let index += 1
-      let counter +=1
+      if elixir#util#is_indentable_at(a:line.num, index)
+        let counter +=1
+      end
     else
       break
     end

--- a/spec/indent/tuples_spec.rb
+++ b/spec/indent/tuples_spec.rb
@@ -23,4 +23,13 @@ describe 'Indenting tuples' do
     end
     EOF
   end
+
+  it 'tuples with strings with embedded braces' do
+    expect(<<~EOF).to be_elixir_indentation
+    x = [
+      {:text, "asd {"},
+      {:text, "qwe"},
+    ]
+    EOF
+  end
 end

--- a/spec/syntax/strings_spec.rb
+++ b/spec/syntax/strings_spec.rb
@@ -95,5 +95,15 @@ describe 'String syntax' do
       expect(str).not_to include_elixir_syntax('elixirInterpolationDelimiter', '}}"$')
       expect(str).to include_elixir_syntax('elixirInterpolationDelimiter', '}"$')
     end
+
+    it 'strings with embedded braces' do
+      str = <<~EOF
+      x = [
+        {:text, "asd {"},
+        {:text, "qwe"},
+      ]
+      EOF
+      expect(str).to include_elixir_syntax('elixirString', '{"}')
+    end
   end
 end


### PR DESCRIPTION
* fixes #266