### PR TITLE
changed colors of modules and aliases

### DIFF
--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -189,7 +189,7 @@ hi def link elixirExceptionDefine        Define
 hi def link elixirCallbackDefine         Define
 hi def link elixirStructDefine           Define
 hi def link elixirExUnitMacro            Define
-hi def link elixirModuleDeclaration      Type
+hi def link elixirModuleDeclaration      Identifier
 hi def link elixirFunctionDeclaration    Function
 hi def link elixirMacroDeclaration       Macro
 hi def link elixirInclude                Include
@@ -201,7 +201,7 @@ hi def link elixirKernelFunction         Keyword
 hi def link elixirOperator               Operator
 hi def link elixirAtom                   Constant
 hi def link elixirPseudoVariable         Constant
-hi def link elixirAlias                  Type
+hi def link elixirAlias                  Identifier
 hi def link elixirBoolean                Boolean
 hi def link elixirVariable               Identifier
 hi def link elixirSelf                   Identifier


### PR DESCRIPTION
Now module names have the same color as keywords. Syntax coloring also does't work as it should when it comes to coloring what's after 'require' keyword. This is affected by elixirAlias. That's my proposal of changes.

Before:
<img width="934" alt="zrzut ekranu 2017-02-04 14 21 31" src="https://cloud.githubusercontent.com/assets/7414533/22618994/dd066e4a-eaea-11e6-8ba1-411c39e087bf.png">

After:
<img width="934" alt="zrzut ekranu 2017-02-04 14 51 44" src="https://cloud.githubusercontent.com/assets/7414533/22619023/8bb95920-eaeb-11e6-8c86-92056340383c.png">
