### PR TITLE
fix indentation when following previous end block

### DIFF
--- a/autoload/elixir/indent.vim
+++ b/autoload/elixir/indent.vim
@@ -22,7 +22,8 @@ function! elixir#indent#indent(lnum)
         \'starts_with_binary_operator',
         \'inside_nested_construct',
         \'starts_with_comment',
-        \'inside_generic_block'
+        \'inside_generic_block',
+        \'following_prev_end'
         \]
   for handler in handlers
     call s:debug('testing handler elixir#indent#handle_'.handler)
@@ -152,6 +153,14 @@ function! elixir#indent#handle_following_trailing_binary_operator(lnum, text, pr
 
   if s:ends_with(a:prev_nb_text, binary_operator, a:prev_nb_lnum)
     return indent(a:prev_nb_lnum) + &sw
+  else
+    return -1
+  endif
+endfunction
+
+function! elixir#indent#handle_following_prev_end(_lnum, _text, prev_nb_lnum, prev_nb_text)
+  if s:ends_with(a:prev_nb_text, s:keyword('end'), a:prev_nb_lnum)
+    return indent(a:prev_nb_lnum)
   else
     return -1
   endif

--- a/spec/indent/def_spec.rb
+++ b/spec/indent/def_spec.rb
@@ -15,4 +15,60 @@ describe 'def indentation' do
 
     def
   EOF
+
+  i <<~EOF
+  defmodule HiMom do
+    def hi do
+      puts "hi"
+    end
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    def mom do
+      puts "mom"
+    end
+  end
+  EOF
 end


### PR DESCRIPTION
The changes to limit the number of lines we search for a block have made
it so that `def` calls in modules don't indent properly. This is because
we're looking for the base module declaration as a reference point and
stop searching before we get there

Instead, we hack around a bit and try to detect this by looking for
the last `end`. This solution isn't perfect, but it's cheap and effective
until we find problems with it