### PR TITLE
spec_helper: detect failed searches

### DIFF
--- a/spec/syntax/doc_spec.rb
+++ b/spec/syntax/doc_spec.rb
@@ -80,7 +80,7 @@ describe 'documentation syntax' do
       EOF
       expect(ex).to include_elixir_syntax('elixirDocString', 'doctest')
       expect(ex).to include_elixir_syntax('elixirDocTest',   'map')
-      expect(ex).to include_elixir_syntax('elixirDocTest',   'x * 2')
+      expect(ex).to include_elixir_syntax('elixirDocTest',   'x \* 2')
       expect(ex).to include_elixir_syntax('elixirDocTest',   '2, 4, 6')
     end
 

--- a/spec/syntax/sigil_spec.rb
+++ b/spec/syntax/sigil_spec.rb
@@ -13,7 +13,7 @@ describe 'Sigil syntax' do
   describe 'upper case' do
     it 'string' do
       expect('~S(string)').to include_elixir_syntax('elixirSigilDelimiter', 'S')
-      expect('~S(string)').to include_elixir_syntax('elixirSigil', 'foo')
+      expect('~S(string)').to include_elixir_syntax('elixirSigil', 'string')
     end
 
     it 'character list' do
@@ -47,7 +47,7 @@ describe 'Sigil syntax' do
     end
 
     it 'escapes double quotes unless only preceded by whitespace' do
-      expect(<<~EOF).to include_elixir_syntax('elixirSigilDelimiter', %q(^\s*\zs'"'))
+      expect(<<~EOF).to include_elixir_syntax('elixirSigilDelimiter', %q(^\s*\zs"""))
         ~r"""
         foo """
         """
@@ -78,7 +78,7 @@ describe 'Sigil syntax' do
   describe 'lower case' do
     it 'string' do
       expect('~s(string)').to include_elixir_syntax('elixirSigilDelimiter', 's')
-      expect('~s(string)').to include_elixir_syntax('elixirSigil', 'foo')
+      expect('~s(string)').to include_elixir_syntax('elixirSigil', 'string')
     end
 
     it 'character list' do


### PR DESCRIPTION
`@vim.search()` silently fails if a pattern is not found and the cursor won't move. So, if the current cursor position happens to sport the expected syntax group already, this can lead to false positive tests.

We work around this by using Vim's `search()` function, which returns 0 if there is no match.
