### PR TITLE
syntax: fix highlighting of Kernel functions

### DIFF
--- a/spec/syntax/guard_spec.rb
+++ b/spec/syntax/guard_spec.rb
@@ -5,24 +5,30 @@ require 'spec_helper'
 describe 'Guard syntax' do
   it 'guard in function' do
     expect(<<~EOF).to include_elixir_syntax('elixirKernelFunction', 'is_atom')
-    def fun(a) when is_atom(a) do
-    end
+    def fun(a) when is_atom(a), do:
+    EOF
+  end
+
+  it 'guard in if' do
+    expect(<<~EOF).to include_elixir_syntax('elixirKernelFunction', 'is_atom')
+    if is_atom(:atom), do: true
     EOF
   end
 
   it 'guard in case' do
     expect(<<~EOF).to include_elixir_syntax('elixirKernelFunction', 'is_atom')
-    case
-      a when is_atom(a) -> {:ok, a}
+    case true do
+      true when is_atom(:atom) -> true
     end
     EOF
   end
 
-  it 'does not highlight outside guards' do
-    expect(<<~EOF).not_to include_elixir_syntax('elixirKernelFunction', 'is_atom')
-      if is_atom(a) do
-        {:ok, a}
-      end
+  it 'guard in case (multiline)' do
+    expect(<<~EOF).to include_elixir_syntax('elixirKernelFunction', 'is_atom')
+    case true do
+      true when is_boolean(true) and
+      is_atom(:atom) -> true
+    end
     EOF
   end
 end

--- a/spec/syntax/kernel_function_spec.rb
+++ b/spec/syntax/kernel_function_spec.rb
@@ -3,14 +3,17 @@
 require 'spec_helper'
 
 describe 'Kernel function syntax' do
-  it 'kernel function used as an atom key in a keyword list contained in a block' do
+  it 'kernel function used as an atom key in a keyword list outside of a block' do
     expect(<<~EOF).not_to include_elixir_syntax('elixirKernelFunction', 'length')
     do
-      plug Plug.Parsers,
-        parsers: [:urlencoded, :multipart, :json],
-        pass: ["*/*"],
-        json_decoder: Poison,
-        length: 400_000_000
+      plug Plug.Parsers, length: 400_000_000
+    end
+    EOF
+  end
+
+  it 'kernel function used as an atom key in a keyword list contained in a block' do
+    expect(<<~EOF).not_to include_elixir_syntax('elixirKernelFunction', 'length')
+    plug Plug.Parsers, length: 400_000_000
     EOF
   end
 

--- a/spec/syntax/kernel_function_spec.rb
+++ b/spec/syntax/kernel_function_spec.rb
@@ -21,19 +21,4 @@ describe 'Kernel function syntax' do
     end
     EOF
   end
-
-  it 'kernel function used in a function body' do
-    expect(<<~'EOF').not_to include_elixir_syntax('elixirKernelFunction', 'length')
-    def say_size(chars) do
-      size = length(chars)
-      IO.puts "you gave me #{size} chars"
-    end
-    EOF
-  end
-
-  it 'kernel function used as top-level' do
-    expect(<<~'EOF').not_to include_elixir_syntax('elixirKernelFunction', 'length')
-    length(chars)
-    EOF
-  end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -16,17 +16,18 @@ syn cluster elixirDeclaration contains=elixirFunctionDeclaration,elixirModuleDec
 syn match elixirComment '#.*' contains=elixirTodo,@Spell
 syn keyword elixirTodo FIXME NOTE TODO OPTIMIZE XXX HACK contained
 
-syn match elixirId '\<[_a-zA-Z]\w*[!?]\?\>' contains=elixirUnusedVariable
+syn match elixirId '\<[_a-zA-Z]\w*[!?]\?\>' contains=elixirUnusedVariable,elixirKernelFunction
 
 syn match elixirKeyword '\(\.\)\@<!\<\(for\|case\|when\|with\|cond\|if\|unless\|try\|receive\|send\)\>'
 syn match elixirKeyword '\(\.\)\@<!\<\(exit\|raise\|throw\|after\|rescue\|catch\|else\)\>'
 syn match elixirKeyword '\(\.\)\@<!\<\(quote\|unquote\|super\|spawn\|spawn_link\|spawn_monitor\)\>'
 
 " Kernel functions
-syn match elixirKernelFunction contained containedin=elixirGuard '\<\(is_atom\|is_binary\|is_bitstring\|is_boolean\|is_float\|is_function\|is_integer\|is_list\|is_map\|is_nil\|is_number\|is_pid\|is_port\)\>\([ (]\)\@='
-syn match elixirKernelFunction contained containedin=elixirGuard '\<\(is_record\|is_reference\|is_tuple\|is_exception\|abs\|bit_size\|byte_size\|div\|elem\|hd\|length\|map_size\|node\|rem\|round\|tl\|trunc\|tuple_size\)\>\([ (]\)\@='
-
-syn match elixirGuard '.*when.*' contains=ALLBUT,@elixirNotTop
+syn keyword elixirKernelFunction contained is_atom is_binary is_bitstring is_boolean is_float
+syn keyword elixirKernelFunction contained is_function is_integer is_list is_map is_nil
+syn keyword elixirKernelFunction contained is_number is_pid is_port is_reference is_tuple
+syn keyword elixirKernelFunction contained abs binary_part bit_size byte_size div elem hd length
+syn keyword elixirKernelFunction contained map_size node rem round tl trunc tuple_size
 
 syn keyword elixirInclude import require alias use
 


### PR DESCRIPTION
Prior to this change, there was a false assumption that Kernel functions can only be used in guards.

But they can appear everywhere where an identifer can appear. Following this rule we can greatly simplify the highlighting of Kernel functions.

Fixes https://github.com/elixir-lang/vim-elixir/issues/340