### PR TITLE
spec_helper: match syntax group exactly

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,10 +52,13 @@ class Buffer
       return []
     end
 
-    # Return the syntax groups in a list.
-    @vim.echo <<~EOF
+    syngroups = @vim.echo <<~EOF
     map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")')
     EOF
+
+    # From: "['elixirRecordDeclaration', 'elixirAtom']"
+    # To:   ["elixirRecordDeclaration", "elixirAtom"]
+    syngroups.gsub!(/["'\[\]]/, '').split(', ')
   end
 
   private

--- a/spec/syntax/sigil_spec.rb
+++ b/spec/syntax/sigil_spec.rb
@@ -97,7 +97,7 @@ describe 'Sigil syntax' do
     end
 
     it 'with escapes' do
-      expect('~s(foo \n bar)').to include_elixir_syntax('elixirRegexEscape', '\\')
+      expect('~s(foo \n bar)').to include_elixir_syntax('elixirRegexEscapePunctuation', '\\')
     end
 
     it 'with interpolation' do
@@ -113,7 +113,7 @@ describe 'Sigil syntax' do
     end
 
     it 'escapes with slashes' do
-      expect('~s/foo \n bar/').to include_elixir_syntax('elixirRegexEscape', '\\')
+      expect('~s/foo \n bar/').to include_elixir_syntax('elixirRegexEscapePunctuation', '\\')
     end
   end
 end

--- a/spec/syntax/struct_spec.rb
+++ b/spec/syntax/struct_spec.rb
@@ -31,7 +31,6 @@ describe 'Struct syntax' do
     expect(str).to include_elixir_syntax('elixirStruct', 'name:')
 
     expect(str).to include_elixir_syntax('elixirStructDelimiter', '}')
-    expect(str).to include_elixir_syntax('elixirStruct', '}')
   end
 
   it 'properly closes strings in structs' do
@@ -59,7 +58,6 @@ describe 'Struct syntax' do
     expect(str).to include_elixir_syntax('elixirStruct', '"}')
 
     expect(str).to include_elixir_syntax('elixirStructDelimiter', '} #')
-    expect(str).to include_elixir_syntax('elixirStruct', '} #')
 
     expect(str).to include_elixir_syntax('elixirComment', '# this should not be a string still')
   end

--- a/spec/syntax/tuple_spec.rb
+++ b/spec/syntax/tuple_spec.rb
@@ -13,6 +13,5 @@ describe 'Tuple syntax' do
     expect(str).to include_elixir_syntax('elixirTuple', ':name')
 
     expect(str).to include_elixir_syntax('elixirTupleDelimiter', '}')
-    expect(str).to include_elixir_syntax('elixirTuple', '}')
   end
 end


### PR DESCRIPTION
Previously, syntax() would return a string containing a Vim list:

```
  "['elixirBlockDefinition']".include? 'elixirBlock'
```

This would match although it is not what we want.

This patch converts the return value of syntax() from a string to a list:

```
  ["elixirBlockDefinition"].include? 'elixirBlock'
```

This does not match anymore.