### PR TITLE
syntax: highlight operators after a . as elixirId

### DIFF
--- a/spec/syntax/operator_spec.rb
+++ b/spec/syntax/operator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'Default argument syntax' do
+describe 'Operators' do
   it 'default argument' do
     expect(<<~'EOF').to include_elixir_syntax('elixirOperator', '\\')
       def foo(bar \\ :baz)
@@ -10,6 +10,16 @@ describe 'Default argument syntax' do
 
     expect(<<~EOF).to include_elixir_syntax('elixirOperator', '\/')
       def foo(bar // :baz)
+    EOF
+  end
+
+  it 'in' do
+    expect(<<~EOF).to include_elixir_syntax('elixirOperator', 'in')
+      'x' in ['x']
+    EOF
+
+    expect(<<~EOF).not_to include_elixir_syntax('elixirOperator', 'in')
+      :queue.in x, 5
     EOF
   end
 end

--- a/syntax/elixir.vim
+++ b/syntax/elixir.vim
@@ -36,7 +36,7 @@ syn keyword elixirSelf self
 " This unfortunately also matches function names in function calls
 syn match elixirUnusedVariable contained '\v%(^|[^.])@<=<_\w*>'
 
-syn keyword elixirOperator and not or in
+syn match   elixirOperator '\v\.@<!%(and|or|in|not)'
 syn match   elixirOperator '!==\|!=\|!'
 syn match   elixirOperator '=\~\|===\|==\|='
 syn match   elixirOperator '<<<\|<<\|<=\|<-\|<'


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/vim-elixir/issues/299

---

@jbodah What do you think about this approach?

It's easier than trying to make all the regexp of `elixirOperator` super smart.

Basically it's.. magic. After a `.` the regexp engine gets a hint to check for `elixirId` first. `elixirId` is defined by 2 patterns. The first matches the same as before and the new one only matches after a `.`, only graphical characters (`&`, `<` etc.), for up to 3 characters (the widest possible operators are `~~~`, `>>>`, etc.) or until the first space or `(`.

Is this sane? ;x